### PR TITLE
fix(filter): add defensive type checking for created_at in ResourceFilter

### DIFF
--- a/src/snapshot/filter.py
+++ b/src/snapshot/filter.py
@@ -117,12 +117,13 @@ class ResourceFilter:
         if not self.before_date and not self.after_date:
             return True
 
-        # If resource has no creation date, we can't filter by date
-        if not resource.created_at:
+        # If resource has no creation date or invalid type, we can't filter by date
+        # Many AWS resources don't expose creation timestamps (VPCs, Security Groups, etc.)
+        if not resource.created_at or not isinstance(resource.created_at, datetime):
             self.stats["missing_creation_date"] += 1
-            # For resources without creation dates, include them if we're being permissive
+            # For resources without valid creation dates, include them (permissive behavior)
             # This is a design choice - could also exclude them
-            logger.debug(f"Resource {resource.arn} has no creation date - including by default")
+            logger.debug(f"Resource {resource.arn} has no valid creation date - including by default")
             return True
 
         # Make sure resource.created_at is timezone-aware for comparison

--- a/tests/unit/test_resource_filter.py
+++ b/tests/unit/test_resource_filter.py
@@ -464,3 +464,73 @@ class TestResourceFilter:
         assert len(filtered) == 0
         assert filter.stats["total_collected"] == 0
         assert filter.stats["final_count"] == 0
+
+    def test_apply_resource_with_invalid_created_at_type_included(self):
+        """Test that resources with invalid created_at type are included when date filters present.
+
+        This handles edge cases where created_at might be a string instead of datetime
+        (e.g., from malformed YAML or API responses).
+        Regression test for issue #37.
+        """
+        cutoff = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        # Create a resource and manually set created_at to an invalid type
+        resource_with_string_date = Resource(
+            arn="arn:aws:s3:::string-date",
+            resource_type="s3:bucket",
+            name="string-date",
+            region="us-east-1",
+            config_hash="1" * 64,
+            raw_config={},
+        )
+        # Simulate invalid type by directly setting the attribute
+        resource_with_string_date.created_at = "2024-05-01T00:00:00Z"  # type: ignore
+
+        resource_with_valid_date = Resource(
+            arn="arn:aws:s3:::valid-date",
+            resource_type="s3:bucket",
+            name="valid-date",
+            region="us-east-1",
+            config_hash="2" * 64,
+            raw_config={},
+            created_at=datetime(2024, 7, 1, 0, 0, 0, tzinfo=timezone.utc),
+        )
+
+        resources = [resource_with_string_date, resource_with_valid_date]
+
+        filter = ResourceFilter(before_date=cutoff)
+        filtered = filter.apply(resources)
+
+        # Resource with invalid created_at type should be included by default (permissive)
+        # Resource with valid date after cutoff should be excluded
+        assert len(filtered) == 1
+        assert filtered[0].name == "string-date"
+        assert filter.stats["missing_creation_date"] == 1
+
+    def test_apply_resource_with_integer_created_at_included(self):
+        """Test that resources with integer created_at (e.g., epoch) are included.
+
+        Some APIs return timestamps as integers. The filter should handle this gracefully.
+        Regression test for issue #37.
+        """
+        cutoff = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        resource_with_int_date = Resource(
+            arn="arn:aws:s3:::int-date",
+            resource_type="s3:bucket",
+            name="int-date",
+            region="us-east-1",
+            config_hash="3" * 64,
+            raw_config={},
+        )
+        # Simulate epoch timestamp as integer
+        resource_with_int_date.created_at = 1717200000  # type: ignore
+
+        resources = [resource_with_int_date]
+
+        filter = ResourceFilter(before_date=cutoff)
+        filtered = filter.apply(resources)
+
+        # Resource with invalid type should be included
+        assert len(filtered) == 1
+        assert filter.stats["missing_creation_date"] == 1


### PR DESCRIPTION
## Summary

- Add `isinstance(resource.created_at, datetime)` check in `ResourceFilter._matches_date_filter()` to handle edge cases where `created_at` might be an invalid type
- Resources with invalid `created_at` types (string, int) are included by default (permissive behavior)
- Added 2 unit tests for string and integer `created_at` edge cases

## Test plan

- [x] Unit tests pass (651 total, 2 new)
- [x] Existing date filtering behavior unchanged
- [x] Resources with `None`, string, or integer `created_at` are included when date filters applied

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)