### PR TITLE
docs: add date-based filtering support documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ When using `--before-date` or `--after-date` filters, note that not all AWS reso
 | EFS | File Systems | CreationTime |
 | EKS | Clusters, Node Groups, Fargate Profiles | createdAt |
 | ECS | Clusters, Services, Task Definitions | createdAt |
+| Lambda | Functions | LastModified |
 | Lambda | Layers | CreatedDate |
 | API Gateway | REST APIs, HTTP APIs | createdDate |
 | Step Functions | State Machines | creationDate |
@@ -360,7 +361,6 @@ When using `--before-date` or `--after-date` filters, note that not all AWS reso
 | EC2 | Subnets | AWS API doesn't provide creation timestamp |
 | SNS | Topics | AWS API doesn't provide creation timestamp |
 | CloudWatch | Log Groups | Not easily exposed via API |
-| Lambda | Functions | Not exposed (only layers have dates) |
 
 **Behavior:** Resources without creation dates are **included by default** when date filters are applied. This ensures you don't accidentally miss resources due to API limitations.
 


### PR DESCRIPTION
## Summary

- Document which AWS resource types support creation date filtering
- Document which resource types lack creation dates and why
- Explain the default behavior (resources without dates are included)
- Update README version to 0.4.3 and status to Production/Stable

## Resources WITH creation dates

EC2 Instances/Volumes, S3 Buckets, RDS, DynamoDB, IAM, ELB, CloudFormation, KMS, EFS, EKS, ECS, Lambda Layers, API Gateway, Step Functions, CodeBuild, CodePipeline, Secrets Manager, Route53, SQS

## Resources WITHOUT creation dates

- EC2: VPCs, Security Groups, Subnets
- SNS: Topics
- CloudWatch: Log Groups
- Lambda: Functions (only layers have dates)

## Test plan

- [x] No code changes, documentation only
- [x] Unit tests pass

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)