### PR TITLE
feat(restore): Add deletion support for SSM, Step Functions, EventBridge, CodeBuild (#54-57)

### DIFF
--- a/src/restore/deleter.py
+++ b/src/restore/deleter.py
@@ -22,6 +22,7 @@ RESOURCES_WITH_PREREQUISITES = {
     "AWS::S3::Bucket",
     "AWS::IAM::Role",
     "AWS::IAM::User",
+    "AWS::Events::Rule",
 }
 
 
@@ -82,6 +83,14 @@ class ResourceDeleter:
         "AWS::EFS::FileSystem": ("efs", "delete_file_system", "FileSystemId"),
         # ElastiCache
         "AWS::ElastiCache::CacheCluster": ("elasticache", "delete_cache_cluster", "CacheClusterId"),
+        # SSM
+        "AWS::SSM::Parameter": ("ssm", "delete_parameter", "Name"),
+        # Step Functions
+        "AWS::StepFunctions::StateMachine": ("sfn", "delete_state_machine", "stateMachineArn"),
+        # EventBridge
+        "AWS::Events::Rule": ("events", "delete_rule", "Name"),
+        # CodeBuild
+        "AWS::CodeBuild::Project": ("codebuild", "delete_project", "name"),
     }
 
     def __init__(self, aws_profile: Optional[str] = None, max_retries: int = 3):
@@ -323,6 +332,8 @@ class ResourceDeleter:
                 return self._cleanup_iam_role(resource_id)
             elif resource_type == "AWS::IAM::User":
                 return self._cleanup_iam_user(resource_id)
+            elif resource_type == "AWS::Events::Rule":
+                return self._cleanup_eventbridge_rule(resource_id, region)
         except Exception as e:
             error_msg = f"Prerequisite cleanup failed for {resource_type} {resource_id}: {str(e)}"
             logger.error(error_msg)
@@ -618,3 +629,58 @@ class ResourceDeleter:
                 return (True, None)  # User already deleted
 
             return (False, f"Failed to cleanup IAM user: {error_code}: {error_message}")
+
+    def _cleanup_eventbridge_rule(self, rule_name: str, region: str) -> tuple[bool, Optional[str]]:
+        """Remove all targets from an EventBridge rule before deletion.
+
+        EventBridge rules cannot be deleted if they have targets attached.
+        This method removes all targets first.
+
+        Args:
+            rule_name: Name of the EventBridge rule
+            region: AWS region
+
+        Returns:
+            Tuple of (success: bool, error_message: Optional[str])
+        """
+        try:
+            events_client = create_boto_client(
+                service_name="events",
+                region_name=region,
+                profile_name=self.aws_profile,
+            )
+
+            # List all targets for this rule
+            targets_to_remove = []
+            paginator = events_client.get_paginator("list_targets_by_rule")
+
+            try:
+                for page in paginator.paginate(Rule=rule_name):
+                    for target in page.get("Targets", []):
+                        targets_to_remove.append(target["Id"])
+            except ClientError as e:
+                if e.response.get("Error", {}).get("Code") == "ResourceNotFoundException":
+                    return (True, None)  # Rule already deleted
+                raise
+
+            # Remove targets in batches of 10 (API limit)
+            if targets_to_remove:
+                for i in range(0, len(targets_to_remove), 10):
+                    batch = targets_to_remove[i : i + 10]
+                    events_client.remove_targets(
+                        Rule=rule_name,
+                        Ids=batch,
+                    )
+                    logger.debug(f"Removed {len(batch)} targets from rule {rule_name}")
+
+            logger.info(f"Cleaned up EventBridge rule {rule_name}: removed {len(targets_to_remove)} targets")
+            return (True, None)
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            error_message = e.response.get("Error", {}).get("Message", str(e))
+
+            if error_code == "ResourceNotFoundException":
+                return (True, None)  # Rule already deleted
+
+            return (False, f"Failed to cleanup EventBridge rule: {error_code}: {error_message}")

--- a/tests/unit/restore/test_deleter.py
+++ b/tests/unit/restore/test_deleter.py
@@ -752,3 +752,170 @@ class TestIAMUserCleanup:
 
         assert success is True
         assert error is None
+
+
+class TestSSMParameterDeletion:
+    """Test suite for SSM Parameter deletion."""
+
+    @patch("src.restore.deleter.create_boto_client")
+    def test_delete_ssm_parameter(self, mock_create_client: Mock) -> None:
+        """Test SSM Parameter deletion."""
+        mock_client = Mock()
+        mock_client.delete_parameter.return_value = {}
+        mock_create_client.return_value = mock_client
+
+        deleter = ResourceDeleter()
+        success, error = deleter.delete_resource(
+            resource_type="AWS::SSM::Parameter",
+            resource_id="/my/parameter",
+            region="us-east-1",
+            arn="arn:aws:ssm:us-east-1:123456789012:parameter/my/parameter",
+        )
+
+        assert success is True
+        assert error is None
+        mock_client.delete_parameter.assert_called_once_with(Name="/my/parameter")
+
+
+class TestStepFunctionsDeletion:
+    """Test suite for Step Functions state machine deletion."""
+
+    @patch("src.restore.deleter.create_boto_client")
+    def test_delete_state_machine(self, mock_create_client: Mock) -> None:
+        """Test Step Functions state machine deletion uses ARN."""
+        mock_client = Mock()
+        mock_client.delete_state_machine.return_value = {}
+        mock_create_client.return_value = mock_client
+
+        deleter = ResourceDeleter()
+        state_machine_arn = "arn:aws:states:us-east-1:123456789012:stateMachine:MyStateMachine"
+        success, error = deleter.delete_resource(
+            resource_type="AWS::StepFunctions::StateMachine",
+            resource_id="MyStateMachine",
+            region="us-east-1",
+            arn=state_machine_arn,
+        )
+
+        assert success is True
+        assert error is None
+        # Should use ARN parameter (stateMachineArn contains "Arn")
+        mock_client.delete_state_machine.assert_called_once_with(stateMachineArn=state_machine_arn)
+
+
+class TestCodeBuildDeletion:
+    """Test suite for CodeBuild project deletion."""
+
+    @patch("src.restore.deleter.create_boto_client")
+    def test_delete_codebuild_project(self, mock_create_client: Mock) -> None:
+        """Test CodeBuild project deletion."""
+        mock_client = Mock()
+        mock_client.delete_project.return_value = {}
+        mock_create_client.return_value = mock_client
+
+        deleter = ResourceDeleter()
+        success, error = deleter.delete_resource(
+            resource_type="AWS::CodeBuild::Project",
+            resource_id="my-build-project",
+            region="us-east-1",
+            arn="arn:aws:codebuild:us-east-1:123456789012:project/my-build-project",
+        )
+
+        assert success is True
+        assert error is None
+        mock_client.delete_project.assert_called_once_with(name="my-build-project")
+
+
+class TestEventBridgeRuleDeletion:
+    """Test suite for EventBridge rule deletion."""
+
+    @patch("src.restore.deleter.create_boto_client")
+    def test_delete_eventbridge_rule_with_targets(self, mock_create_client: Mock) -> None:
+        """Test EventBridge rule deletion removes targets first."""
+        mock_client = Mock()
+        # Mock targets exist
+        mock_paginator = Mock()
+        mock_paginator.paginate.return_value = [{"Targets": [{"Id": "target-1"}, {"Id": "target-2"}]}]
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_client.remove_targets.return_value = {}
+        mock_client.delete_rule.return_value = {}
+        mock_create_client.return_value = mock_client
+
+        deleter = ResourceDeleter()
+        success, error = deleter.delete_resource(
+            resource_type="AWS::Events::Rule",
+            resource_id="my-rule",
+            region="us-east-1",
+            arn="arn:aws:events:us-east-1:123456789012:rule/my-rule",
+        )
+
+        assert success is True
+        assert error is None
+        # Should have removed targets first
+        mock_client.remove_targets.assert_called_once_with(
+            Rule="my-rule",
+            Ids=["target-1", "target-2"],
+        )
+        # Then deleted the rule
+        mock_client.delete_rule.assert_called_once_with(Name="my-rule")
+
+    @patch("src.restore.deleter.create_boto_client")
+    def test_delete_eventbridge_rule_no_targets(self, mock_create_client: Mock) -> None:
+        """Test EventBridge rule deletion with no targets."""
+        mock_client = Mock()
+        # Mock no targets
+        mock_paginator = Mock()
+        mock_paginator.paginate.return_value = [{"Targets": []}]
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_client.delete_rule.return_value = {}
+        mock_create_client.return_value = mock_client
+
+        deleter = ResourceDeleter()
+        success, error = deleter.delete_resource(
+            resource_type="AWS::Events::Rule",
+            resource_id="empty-rule",
+            region="us-east-1",
+            arn="arn:aws:events:us-east-1:123456789012:rule/empty-rule",
+        )
+
+        assert success is True
+        assert error is None
+        # Should NOT have called remove_targets
+        mock_client.remove_targets.assert_not_called()
+        mock_client.delete_rule.assert_called_once()
+
+    @patch("src.restore.deleter.create_boto_client")
+    def test_cleanup_eventbridge_rule_already_deleted(self, mock_create_client: Mock) -> None:
+        """Test EventBridge rule cleanup when rule doesn't exist."""
+        mock_client = Mock()
+        mock_paginator = Mock()
+        mock_paginator.paginate.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException", "Message": "Rule not found"}},
+            "ListTargetsByRule",
+        )
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_create_client.return_value = mock_client
+
+        deleter = ResourceDeleter()
+        success, error = deleter._cleanup_eventbridge_rule("deleted-rule", "us-east-1")
+
+        assert success is True  # Already gone is success
+        assert error is None
+
+    @patch("src.restore.deleter.create_boto_client")
+    def test_cleanup_eventbridge_rule_many_targets(self, mock_create_client: Mock) -> None:
+        """Test EventBridge rule cleanup with more than 10 targets (batch limit)."""
+        mock_client = Mock()
+        # Mock 15 targets to test batching
+        targets = [{"Id": f"target-{i}"} for i in range(15)]
+        mock_paginator = Mock()
+        mock_paginator.paginate.return_value = [{"Targets": targets}]
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_client.remove_targets.return_value = {}
+        mock_create_client.return_value = mock_client
+
+        deleter = ResourceDeleter()
+        success, error = deleter._cleanup_eventbridge_rule("busy-rule", "us-east-1")
+
+        assert success is True
+        # Should have called remove_targets twice (10 + 5)
+        assert mock_client.remove_targets.call_count == 2


### PR DESCRIPTION
## Summary
Adds 4 new deletable resource types commonly found in lab environments:

| Resource Type | Service | Prerequisite |
|---------------|---------|--------------|
| `AWS::SSM::Parameter` | SSM | None |
| `AWS::StepFunctions::StateMachine` | Step Functions | None |
| `AWS::Events::Rule` | EventBridge | Remove targets first |
| `AWS::CodeBuild::Project` | CodeBuild | None |

## Changes
- Added 4 new entries to `DELETION_METHODS`
- Added `AWS::Events::Rule` to `RESOURCES_WITH_PREREQUISITES`
- Added `_cleanup_eventbridge_rule()` method to remove targets before deletion
- Added 7 new unit tests

## Test plan
- [x] All 39 deleter unit tests pass
- [x] Linting passes
- [x] Formatting passes

Closes #54, Closes #55, Closes #56, Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)