### PR TITLE
feat(cli): rename restore command to cleanup for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-01-14
+
+### Changed
+- **BREAKING**: Renamed `restore` command to `cleanup` for clarity
+  - `awsinv restore preview` → `awsinv cleanup preview`
+  - `awsinv restore execute` → `awsinv cleanup execute`
+  - `awsinv restore purge` → `awsinv cleanup purge`
+  - Config file renamed: `.awsinv-restore.yaml` → `.awsinv-cleanup.yaml`
+  - The term "restore" was misleading as the command deletes resources
+
+### Migration
+- Update any scripts using `awsinv restore` to use `awsinv cleanup`
+- Rename any `.awsinv-restore.yaml` files to `.awsinv-cleanup.yaml`
+
 ## [0.8.1] - 2026-01-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # AWS Inventory Manager
 
-### *Snapshot, Track, Secure, and Restore Your AWS Environment*
+### *Snapshot, Track, Secure, and Clean Up Your AWS Environment*
 
 [![CI](https://github.com/troylar/aws-inventory-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/troylar/aws-inventory-manager/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/troylar/aws-inventory-manager/branch/main/graph/badge.svg)](https://codecov.io/gh/troylar/aws-inventory-manager)
@@ -35,8 +35,8 @@ awsinv delta --snapshot my-baseline --show-diff
 awsinv security scan --severity HIGH
 
 # Remove resources created after the baseline
-awsinv restore preview my-baseline      # See what would be deleted
-awsinv restore execute my-baseline --confirm  # Execute cleanup
+awsinv cleanup preview my-baseline      # See what would be deleted
+awsinv cleanup execute my-baseline --confirm  # Execute cleanup
 ```
 
 ### Why You Need This
@@ -59,7 +59,7 @@ Before diving in, here's the terminology:
 |------|---------|
 | **Snapshot** | A point-in-time inventory of your AWS resources (stored in local SQLite database). Not an EBS/RDS snapshot. |
 | **Inventory** | A named collection of snapshots. Use inventories to organize snapshots by environment, team, or purpose. |
-| **Restore** | Delete resources that were created *after* a snapshot, returning to that baseline state. |
+| **Cleanup** | Delete resources that were created *after* a snapshot, returning to that baseline state. |
 | **Purge** | Delete all resources *except* those matching protection rules (no snapshot comparison needed). |
 | **Query** | Search and analyze resources across snapshots using SQL or built-in filters. |
 
@@ -114,7 +114,7 @@ Before diving in, here's the terminology:
 <td width="33%" valign="top">
 
 ### Resource Cleanup
-- **Restore**: Return to a snapshot baseline
+- **Cleanup**: Return to a snapshot baseline
 - **Purge**: Delete all except protected
 - Preview mode (dry-run)
 - Dependency-aware deletion
@@ -216,12 +216,12 @@ awsinv delta --snapshot my-baseline --show-diff
 awsinv security scan
 
 # Clean up resources created after baseline
-awsinv restore preview my-baseline      # Always preview first!
-awsinv restore execute my-baseline --confirm
+awsinv cleanup preview my-baseline      # Always preview first!
+awsinv cleanup execute my-baseline --confirm
 
 # Clean up a sandbox (keep only tagged resources)
-awsinv restore purge --protect-tag "keep=true" --preview
-awsinv restore purge --protect-tag "keep=true" --confirm
+awsinv cleanup purge --protect-tag "keep=true" --preview
+awsinv cleanup purge --protect-tag "keep=true" --confirm
 ```
 
 ---
@@ -327,7 +327,7 @@ By default, all data is stored locally in a SQLite database:
 ~/.snapshots/
 ├── inventory.db              # SQLite database (snapshots, resources, tags)
 └── audit-logs/
-    └── restore/              # Cleanup operation logs
+    └── cleanup/              # Cleanup operation audit logs
         └── 2026-01-15_cleanup.yaml
 ```
 
@@ -527,7 +527,7 @@ For the `awsinv cost` command:
 }
 ```
 
-### Resource Cleanup (restore/purge)
+### Resource Cleanup
 
 ⚠️ **Warning:** These permissions allow resource deletion. Use with extreme caution.
 
@@ -612,29 +612,29 @@ For the `awsinv cost` command:
 
 ## Documentation
 
-### Resource Cleanup (Restore & Purge)
+### Resource Cleanup
 
-The `restore` command has two modes:
+The `cleanup` command has two modes:
 
-**Restore Mode** - Delete resources created *after* a snapshot:
+**Execute Mode** - Delete resources created *after* a baseline snapshot:
 ```bash
 # Preview what would be deleted
-awsinv restore preview my-baseline
+awsinv cleanup preview my-baseline
 
 # Execute (requires confirmation)
-awsinv restore execute my-baseline --confirm
+awsinv cleanup execute my-baseline --confirm
 ```
 
 **Purge Mode** - Delete *all* resources except those matching protection rules:
 ```bash
 # Preview what would be deleted (everything except keep=true tagged resources)
-awsinv restore purge --protect-tag "keep=true" --preview
+awsinv cleanup purge --protect-tag "keep=true" --preview
 
 # Execute
-awsinv restore purge --protect-tag "keep=true" --confirm
+awsinv cleanup purge --protect-tag "keep=true" --confirm
 ```
 
-> **Why "restore"?** The command "restores" your account to a previous state by removing what was added. Think of it as "restore to baseline" rather than "restore a backup."
+> **Note:** `cleanup execute` compares to a snapshot and deletes newer resources. `cleanup purge` ignores snapshots and deletes everything except protected resources.
 
 ### Protection Rules
 
@@ -642,16 +642,16 @@ Prevent accidental deletion of important resources:
 
 ```bash
 # Protect by tag (OR logic - any match protects)
-awsinv restore preview my-snapshot --protect-tag "env=prod" --protect-tag "keep=true"
+awsinv cleanup preview my-snapshot --protect-tag "env=prod" --protect-tag "keep=true"
 
 # Filter to specific resource type (only delete this type)
-awsinv restore preview my-snapshot --type AWS::EC2::Instance
+awsinv cleanup preview my-snapshot --type AWS::EC2::Instance
 
 # Use a config file for complex rules
-awsinv restore preview my-snapshot --config .awsinv-restore.yaml
+awsinv cleanup preview my-snapshot --config .awsinv-cleanup.yaml
 ```
 
-Example `.awsinv-restore.yaml`:
+Example `.awsinv-cleanup.yaml`:
 ```yaml
 # Protection Rules Configuration
 # Resources matching ANY rule are protected from deletion
@@ -813,13 +813,13 @@ awsinv cost                           # Cost analysis
 # ─────────────────────────────────────────────────────────────
 # RESOURCE CLEANUP
 # ─────────────────────────────────────────────────────────────
-# Restore: Delete resources created AFTER a snapshot
-awsinv restore preview <snapshot>     # Dry-run (safe)
-awsinv restore execute <snapshot> --confirm
+# Cleanup: Delete resources created AFTER a snapshot
+awsinv cleanup preview <snapshot>     # Dry-run (safe)
+awsinv cleanup execute <snapshot> --confirm
 
 # Purge: Delete ALL resources EXCEPT protected ones
-awsinv restore purge --protect-tag <key=value> --preview
-awsinv restore purge --protect-tag <key=value> --confirm
+awsinv cleanup purge --protect-tag <key=value> --preview
+awsinv cleanup purge --protect-tag <key=value> --confirm
 
 # Common options for both:
     [--type <AWS::Service::Type>]     # Filter by resource type
@@ -876,8 +876,8 @@ awsinv query stats --group-by region
 awsinv snapshot create morning-baseline --regions us-east-1
 
 # Evening: Clean up everything created during the day
-awsinv restore preview morning-baseline   # Always preview first!
-awsinv restore execute morning-baseline --confirm
+awsinv cleanup preview morning-baseline   # Always preview first!
+awsinv cleanup execute morning-baseline --confirm
 ```
 
 ### Sandbox Account Cleanup
@@ -888,9 +888,9 @@ awsinv restore execute morning-baseline --confirm
 # Tag your permanent infrastructure with "baseline=true"
 # Then periodically purge everything else
 
-awsinv restore purge --protect-tag "baseline=true" --preview
+awsinv cleanup purge --protect-tag "baseline=true" --preview
 # Review the preview output carefully!
-awsinv restore purge --protect-tag "baseline=true" --confirm
+awsinv cleanup purge --protect-tag "baseline=true" --confirm
 ```
 
 ### Pre/Post Deployment Comparison
@@ -933,7 +933,7 @@ awsinv cost --snapshot team-data
 │                                                               │
 │  CLI Commands                                                 │
 │  ┌─────────┐ ┌─────────┐ ┌──────────┐ ┌──────┐ ┌─────────┐   │
-│  │snapshot │ │ delta   │ │ security │ │ cost │ │ restore │   │
+│  │snapshot │ │ delta   │ │ security │ │ cost │ │ cleanup │   │
 │  └────┬────┘ └────┬────┘ └────┬─────┘ └──┬───┘ └────┬────┘   │
 │       │           │           │          │          │         │
 ├───────┴───────────┴───────────┴──────────┴──────────┴────────┤
@@ -983,7 +983,7 @@ invoke quality --fix     # Auto-fix issues
 invoke build             # Build distributable package
 ```
 
-**Test Coverage:** 1550+ tests, 79% overall coverage. Restore module: 98%+ coverage.
+**Test Coverage:** 1550+ tests, 79% overall coverage. Cleanup module: 98%+ coverage.
 
 ---
 
@@ -1038,11 +1038,11 @@ awsinv snapshot create quick-snap --regions us-east-1 --resource-types ec2,lambd
 3. Check that source accounts are properly linked in the aggregator
 4. Run from the aggregator's account/region (typically management account)
 
-#### Restore preview shows unexpected resources
+#### Cleanup preview shows unexpected resources
 
-**Problem:** The restore preview shows resources you didn't expect to be deleted.
+**Problem:** The cleanup preview shows resources you didn't expect to be deleted.
 
-**Explanation:** Restore deletes resources that exist now but didn't exist in the snapshot. This includes:
+**Explanation:** Cleanup deletes resources that exist now but didn't exist in the snapshot. This includes:
 - Resources created after the snapshot
 - Resources in regions not included in the original snapshot
 - AWS-managed resources that get auto-created
@@ -1082,7 +1082,7 @@ awsinv snapshot create quick-snap --regions us-east-1 --resource-types ec2,lambd
 
 #### Q: Is my AWS data sent anywhere?
 
-**No.** All data stays local. The tool only makes read API calls to AWS (and delete calls if you use restore/purge). All data is stored in a SQLite database at `~/.snapshots/inventory.db` on your local machine.
+**No.** All data stays local. The tool only makes read API calls to AWS (and delete calls if you use cleanup). All data is stored in a SQLite database at `~/.snapshots/inventory.db` on your local machine.
 
 #### Q: Can I use this with AWS Organizations?
 
@@ -1100,12 +1100,12 @@ The tool handles partial Config coverage gracefully:
 
 You can see which method was used per resource via the `source` field in snapshots.
 
-#### Q: How do I undo a restore operation?
+#### Q: How do I undo a cleanup operation?
 
 **You can't.** Deleted resources are permanently deleted. Always:
-1. Use `restore preview` first
+1. Use `cleanup preview` first
 2. Review the output carefully
-3. Consider creating a fresh snapshot before restore
+3. Consider creating a fresh snapshot before cleanup
 4. Use `--protect-tag` to safeguard important resources
 
 #### Q: Can I schedule automatic snapshots?
@@ -1132,14 +1132,14 @@ The tool works anywhere with Python and AWS credentials:
 
 For team use, consider storing snapshots in a shared location (see [Data Storage](#data-storage)).
 
-#### Q: Why does restore delete my VPC?
+#### Q: Why does cleanup delete my VPC?
 
-When you restore to a baseline, the tool deletes resources created after that baseline. If the VPC was created after your snapshot, it will be marked for deletion.
+When you run cleanup execute against a baseline, the tool deletes resources created after that baseline. If the VPC was created after your snapshot, it will be marked for deletion.
 
 **Best practice:** Always include networking infrastructure in your baseline snapshot, or protect it with tags:
 
 ```bash
-awsinv restore execute my-baseline --protect-tag "layer=network" --confirm
+awsinv cleanup execute my-baseline --protect-tag "layer=network" --confirm
 ```
 
 ---
@@ -1175,6 +1175,6 @@ MIT License - see [LICENSE](LICENSE)
 
 [![Star on GitHub](https://img.shields.io/github/stars/troylar/aws-inventory-manager?style=social)](https://github.com/troylar/aws-inventory-manager)
 
-Version 0.8.0 • Python 3.8 - 3.13
+Version 0.9.0 • Python 3.8 - 3.13
 
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws-inventory-manager"
-version = "0.8.1"
+version = "0.9.0"
 description = "AWS Resource Inventory Management & Delta Tracking CLI tool"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """AWS Baseline Snapshot & Delta Tracking tool."""
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -2074,13 +2074,13 @@ def security_scan(
 app.add_typer(security_app, name="security")
 
 
-# Restore commands
-restore_app = typer.Typer(help="Resource cleanup and restoration commands")
+# Cleanup commands (destructive operations)
+cleanup_app = typer.Typer(help="Delete resources - returns environment to baseline or removes unprotected resources")
 
 
-@restore_app.command("preview")
-def restore_preview(
-    baseline_snapshot: str = typer.Argument(..., help="Snapshot name to restore to (can be any snapshot)"),
+@cleanup_app.command("preview")
+def cleanup_preview(
+    baseline_snapshot: str = typer.Argument(..., help="Baseline snapshot - resources created after this will be deleted"),
     account_id: str = typer.Option(None, "--account-id", help="AWS account ID (auto-detected if not provided)"),
     profile: Optional[str] = typer.Option(None, "--profile", help="AWS profile name"),
     resource_types: Optional[List[str]] = typer.Option(
@@ -2095,26 +2095,26 @@ def restore_preview(
     ),
     output_format: str = typer.Option("table", "--format", help="Output format: table, json, yaml"),
 ):
-    """Preview resources that would be deleted to restore to a snapshot.
+    """Preview resources that would be DELETED to return to a baseline snapshot.
 
     Shows what resources have been created since the snapshot without
     performing any deletions. This is a safe dry-run operation.
 
     Examples:
-        # Preview resources since a baseline snapshot
-        awsinv restore preview prod-baseline
+        # Preview resources created since a baseline snapshot
+        awsinv cleanup preview prod-baseline
 
         # Preview with tag-based protection
-        awsinv restore preview my-snapshot --protect-tag "project=baseline"
+        awsinv cleanup preview my-snapshot --protect-tag "project=baseline"
 
         # Preview with multiple protection tags
-        awsinv restore preview my-snapshot --protect-tag "project=baseline" --protect-tag "env=prod"
+        awsinv cleanup preview my-snapshot --protect-tag "project=baseline" --protect-tag "env=prod"
 
         # Preview with config file
-        awsinv restore preview my-snapshot --config .awsinv-restore.yaml
+        awsinv cleanup preview my-snapshot --config .awsinv-cleanup.yaml
 
         # Preview only EC2 instances in us-east-1
-        awsinv restore preview my-snapshot --type AWS::EC2::Instance --region us-east-1
+        awsinv cleanup preview my-snapshot --type AWS::EC2::Instance --region us-east-1
     """
     from ..aws.credentials import get_account_id
     from ..restore.audit import AuditStorage
@@ -2194,9 +2194,9 @@ def restore_preview(
         if operation.total_resources > operation.skipped_count:
             deletable_count = operation.total_resources - operation.skipped_count
             console.print(
-                f"\n[yellow]⚠️  {deletable_count} resource(s) would be DELETED if you run 'restore execute'[/yellow]"
+                f"\n[yellow]⚠️  {deletable_count} resource(s) would be DELETED if you run 'cleanup execute'[/yellow]"
             )
-            console.print("[dim]Use 'awsinv restore execute' with --confirm to actually delete resources[/dim]\n")
+            console.print("[dim]Use 'awsinv cleanup execute' with --confirm to actually delete resources[/dim]\n")
         else:
             console.print("\n[green]✓ No resources would be deleted - environment matches baseline[/green]\n")
 
@@ -2205,13 +2205,13 @@ def restore_preview(
         raise typer.Exit(code=1)
     except Exception as e:
         console.print(f"\n[red]Unexpected error: {e}[/red]\n")
-        logger.exception("Error in restore preview command")
+        logger.exception("Error in cleanup preview command")
         raise typer.Exit(code=2)
 
 
-@restore_app.command("execute")
-def restore_execute(
-    baseline_snapshot: str = typer.Argument(..., help="Snapshot name to restore to (can be any snapshot)"),
+@cleanup_app.command("execute")
+def cleanup_execute(
+    baseline_snapshot: str = typer.Argument(..., help="Baseline snapshot - resources created after this will be deleted"),
     account_id: str = typer.Option(None, "--account-id", help="AWS account ID (auto-detected if not provided)"),
     profile: Optional[str] = typer.Option(None, "--profile", help="AWS profile name"),
     resource_types: Optional[List[str]] = typer.Option(None, "--type", help="Filter by resource types"),
@@ -2225,25 +2225,25 @@ def restore_execute(
     confirm: bool = typer.Option(False, "--confirm", help="Confirm deletion (REQUIRED for execution)"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip interactive confirmation prompt"),
 ):
-    """Execute resource deletion to restore environment to a snapshot.
+    """DELETE resources created after a baseline snapshot.
 
-    DESTRUCTIVE OPERATION: This will permanently delete AWS resources!
+    ⚠️  DESTRUCTIVE OPERATION: This will permanently delete AWS resources!
 
-    Deletes resources that were created after the snapshot, restoring
-    your AWS environment to that point in time. Protected resources are skipped.
+    Deletes resources that were created after the snapshot, returning
+    your AWS environment to that baseline state. Protected resources are skipped.
 
     Examples:
-        # Restore with tag-based protection
-        awsinv restore execute my-snapshot --protect-tag "project=baseline" --confirm
+        # Delete resources created after baseline, protecting tagged resources
+        awsinv cleanup execute my-snapshot --protect-tag "project=baseline" --confirm
 
-        # Restore with config file
-        awsinv restore execute my-snapshot --config .awsinv-restore.yaml --confirm
+        # Use config file for protection rules
+        awsinv cleanup execute my-snapshot --config .awsinv-cleanup.yaml --confirm
 
-        # Execute with filters and skip prompt
-        awsinv restore execute my-snapshot --confirm --yes --type AWS::EC2::Instance
+        # Delete only EC2 instances, skip prompt
+        awsinv cleanup execute my-snapshot --confirm --yes --type AWS::EC2::Instance
 
-        # Execute in specific region with profile
-        awsinv restore execute my-snapshot --confirm --region us-east-1 --profile prod
+        # Delete in specific region with profile
+        awsinv cleanup execute my-snapshot --confirm --region us-east-1 --profile prod
     """
     from ..aws.credentials import get_account_id
     from ..restore.audit import AuditStorage
@@ -2256,7 +2256,7 @@ def restore_execute(
         if not confirm:
             console.print("\n[red]ERROR: --confirm flag is required for deletion operations[/red]")
             console.print("[yellow]This is a safety measure to prevent accidental deletions[/yellow]")
-            console.print("\n[dim]Run with: awsinv restore execute <snapshot> --confirm[/dim]\n")
+            console.print("\n[dim]Run with: awsinv cleanup execute <snapshot> --confirm[/dim]\n")
             raise typer.Exit(code=1)
 
         console.print("\n[bold red]⚠️  DESTRUCTIVE OPERATION[/bold red]\n")
@@ -2377,12 +2377,12 @@ def restore_execute(
         raise typer.Exit(code=1)
     except Exception as e:
         console.print(f"\n[red]Unexpected error: {e}[/red]\n")
-        logger.exception("Error in restore execute command")
+        logger.exception("Error in cleanup execute command")
         raise typer.Exit(code=2)
 
 
-@restore_app.command("purge")
-def restore_purge(
+@cleanup_app.command("purge")
+def cleanup_purge(
     account_id: str = typer.Option(None, "--account-id", help="AWS account ID (auto-detected if not provided)"),
     profile: Optional[str] = typer.Option(None, "--profile", help="AWS profile name"),
     resource_types: Optional[List[str]] = typer.Option(None, "--type", help="Filter by resource types"),
@@ -2397,33 +2397,33 @@ def restore_purge(
     confirm: bool = typer.Option(False, "--confirm", help="Confirm deletion (REQUIRED for execution)"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip interactive confirmation prompt"),
 ):
-    """Delete all resources EXCEPT those matching protection rules.
+    """DELETE all resources EXCEPT those matching protection rules.
 
-    DESTRUCTIVE OPERATION: This will permanently delete AWS resources!
+    ⚠️  DESTRUCTIVE OPERATION: This will permanently delete AWS resources!
 
-    Unlike 'restore', this command does NOT compare to a snapshot. It deletes
+    Unlike 'cleanup execute', this does NOT compare to a snapshot. It deletes
     ALL resources that don't match protection rules (tags, types, etc.).
 
     Use this for lab/sandbox cleanup where baseline resources are tagged.
 
     Examples:
         # Preview what would be deleted (safe)
-        awsinv restore purge --protect-tag "project=baseline" --preview
+        awsinv cleanup purge --protect-tag "project=baseline" --preview
 
         # Delete everything except baseline-tagged resources
-        awsinv restore purge --protect-tag "project=baseline" --confirm
+        awsinv cleanup purge --protect-tag "project=baseline" --confirm
 
         # Multiple protection tags (OR logic - protected if ANY match)
-        awsinv restore purge --protect-tag "project=baseline" --protect-tag "env=prod" --confirm
+        awsinv cleanup purge --protect-tag "project=baseline" --protect-tag "env=prod" --confirm
 
         # Use config file for protection rules
-        awsinv restore purge --config .awsinv-restore.yaml --confirm
+        awsinv cleanup purge --config .awsinv-cleanup.yaml --confirm
 
         # Purge only specific resource types
-        awsinv restore purge --protect-tag "project=baseline" --type AWS::EC2::Instance --confirm
+        awsinv cleanup purge --protect-tag "project=baseline" --type AWS::EC2::Instance --confirm
 
         # Purge in specific region
-        awsinv restore purge --protect-tag "project=baseline" --region us-east-1 --confirm
+        awsinv cleanup purge --protect-tag "project=baseline" --region us-east-1 --confirm
     """
     from ..aws.credentials import get_account_id
     from ..restore.audit import AuditStorage
@@ -2441,7 +2441,7 @@ def restore_purge(
         if not protection_rules:
             console.print("\n[red]ERROR: At least one protection rule is required for purge[/red]")
             console.print("[yellow]Use --protect-tag or --config to specify what to keep[/yellow]")
-            console.print("\n[dim]Example: awsinv restore purge --protect-tag \"project=baseline\" --preview[/dim]\n")
+            console.print("\n[dim]Example: awsinv cleanup purge --protect-tag \"project=baseline\" --preview[/dim]\n")
             raise typer.Exit(code=1)
 
         if preview:
@@ -2450,7 +2450,7 @@ def restore_purge(
             if not confirm:
                 console.print("\n[red]ERROR: --confirm flag is required for purge operations[/red]")
                 console.print("[yellow]This is a safety measure to prevent accidental deletions[/yellow]")
-                console.print("\n[dim]Run with: awsinv restore purge --protect-tag \"key=value\" --confirm[/dim]\n")
+                console.print("\n[dim]Run with: awsinv cleanup purge --protect-tag \"key=value\" --confirm[/dim]\n")
                 raise typer.Exit(code=1)
             console.print("\n[bold red]⚠️  PURGE OPERATION - DESTRUCTIVE[/bold red]\n")
 
@@ -2601,7 +2601,7 @@ def restore_purge(
         raise typer.Exit(code=2)
 
 
-app.add_typer(restore_app, name="restore")
+app.add_typer(cleanup_app, name="cleanup")
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- **BREAKING CHANGE**: Renamed `restore` command to `cleanup` for clarity
- `awsinv restore preview` → `awsinv cleanup preview`
- `awsinv restore execute` → `awsinv cleanup execute`
- `awsinv restore purge` → `awsinv cleanup purge`
- Config file: `.awsinv-restore.yaml` → `.awsinv-cleanup.yaml`

## Rationale
The term "restore" was misleading as the command deletes resources rather than restoring them. "Cleanup" more accurately describes the operation of removing resources created after a snapshot.

## Migration
Users should update any scripts using `awsinv restore` to use `awsinv cleanup`.

## Test plan
- [x] All 1551 tests passing
- [x] Updated README references
- [x] Updated CHANGELOG with migration guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)