### PR TITLE
feat(guardrails): add built-in best-practice guardrails that run by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws-inventory-manager"
-version = "1.2.0"
+version = "1.3.0"
 description = "AWS Resource Inventory Management & Delta Tracking CLI tool"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/cli/generation_progress.py
+++ b/src/cli/generation_progress.py
@@ -78,6 +78,21 @@ class ComparisonResult:
     summary: str = ""
 
 
+@dataclass
+class GuardrailsResult:
+    """Track guardrails evaluation results."""
+
+    total_evaluations: int = 0
+    passed: int = 0
+    failed: int = 0
+    auto_fixed: int = 0
+    warnings: int = 0
+    blocked: bool = False
+    block_reason: str = ""
+    current_guardrail: str = ""
+    current_resource: str = ""
+
+
 class GenerationProgressDisplay:
     """Manages real-time generation progress display with detailed workflow view."""
 
@@ -92,6 +107,11 @@ class GenerationProgressDisplay:
             "name": "Build Resource Map",
             "icon": "🔗",
             "description": "Creating AWS ID to reference mapping",
+        },
+        WorkflowStep.EVALUATE_GUARDRAILS: {
+            "name": "Evaluate Guardrails",
+            "icon": "🛡️",
+            "description": "Checking compliance policies",
         },
         WorkflowStep.CATEGORIZE_LAYERS: {
             "name": "Categorize Layers",
@@ -165,6 +185,9 @@ class GenerationProgressDisplay:
         self.lambda_functions_extracted: int = 0
         self.activity_history: List[str] = []  # Recent activity messages
         self.max_activity_history: int = 3  # Show last N activities
+        self.guardrails: Optional[GuardrailsResult] = None
+        self.guardrails_enabled: bool = False
+        self.best_practices_mode: bool = False
 
         # Initialize all steps
         for step in WorkflowStep:
@@ -285,6 +308,59 @@ class GenerationProgressDisplay:
         self.validation_errors = errors
         self._refresh()
 
+    def enable_guardrails(self, best_practices_mode: bool = False) -> None:
+        """Enable guardrails tracking.
+
+        Args:
+            best_practices_mode: If True, show "Best Practices" label instead of "Evaluate Guardrails".
+        """
+        self.guardrails_enabled = True
+        self.best_practices_mode = best_practices_mode
+        self.guardrails = GuardrailsResult()
+        self._refresh()
+
+    def update_guardrails_progress(
+        self,
+        current_guardrail: str = "",
+        current_resource: str = "",
+        passed: int = 0,
+        failed: int = 0,
+        auto_fixed: int = 0,
+        warnings: int = 0,
+        total: int = 0,
+    ) -> None:
+        """Update guardrails evaluation progress."""
+        if self.guardrails:
+            self.guardrails.current_guardrail = current_guardrail
+            self.guardrails.current_resource = current_resource
+            self.guardrails.passed = passed
+            self.guardrails.failed = failed
+            self.guardrails.auto_fixed = auto_fixed
+            self.guardrails.warnings = warnings
+            self.guardrails.total_evaluations = total
+        self._refresh()
+
+    def set_guardrails_result(
+        self,
+        passed: int,
+        failed: int,
+        auto_fixed: int,
+        warnings: int,
+        blocked: bool = False,
+        block_reason: str = "",
+    ) -> None:
+        """Set final guardrails result."""
+        if self.guardrails:
+            self.guardrails.passed = passed
+            self.guardrails.failed = failed
+            self.guardrails.auto_fixed = auto_fixed
+            self.guardrails.warnings = warnings
+            self.guardrails.blocked = blocked
+            self.guardrails.block_reason = block_reason
+            self.guardrails.current_guardrail = ""
+            self.guardrails.current_resource = ""
+        self._refresh()
+
     def _get_layer_icon(self, layer_name: str) -> str:
         """Get icon for a layer name."""
         for key, icon in self.LAYER_ICONS.items():
@@ -318,6 +394,11 @@ class GenerationProgressDisplay:
     def _get_step_config(self, step: WorkflowStep) -> Dict[str, str]:
         """Get step configuration with format-specific overrides."""
         config = dict(self.STEP_CONFIG_BASE[step])
+
+        # Best-practice mode label override
+        if step == WorkflowStep.EVALUATE_GUARDRAILS and self.best_practices_mode:
+            config["name"] = "Best Practices"
+            config["description"] = "Advisory best-practice checks"
 
         # Format-specific overrides
         if self._is_cdk_format():
@@ -385,16 +466,21 @@ class GenerationProgressDisplay:
         steps_table.add_column("Time", width=8)
         steps_table.add_column("Details", style="dim")
 
+        # Build workflow order - include guardrails only if enabled
         workflow_order = [
             WorkflowStep.PARSE_INVENTORY,
             WorkflowStep.BUILD_RESOURCE_MAP,
+        ]
+        if self.guardrails_enabled:
+            workflow_order.append(WorkflowStep.EVALUATE_GUARDRAILS)
+        workflow_order.extend([
             WorkflowStep.CATEGORIZE_LAYERS,
             WorkflowStep.EXTRACT_LAMBDA,
             WorkflowStep.GENERATE_LAYERS,
             WorkflowStep.COMPARE_INVENTORY,
             WorkflowStep.TERRAFORM_INIT,
             WorkflowStep.TERRAFORM_VALIDATE,
-        ]
+        ])
 
         for step in workflow_order:
             config = self._get_step_config(step)
@@ -448,6 +534,23 @@ class GenerationProgressDisplay:
                 details = f"{self.comparison.coverage_percentage:.0f}% coverage"
             elif step == WorkflowStep.TERRAFORM_VALIDATE and self.validation_errors:
                 details = f"{len(self.validation_errors)} warnings"
+            elif step == WorkflowStep.EVALUATE_GUARDRAILS and self.guardrails:
+                gr = self.guardrails
+                if tracked and tracked.status == "running":
+                    if gr.current_guardrail:
+                        details = f"Checking {gr.current_guardrail}..."
+                    else:
+                        total = gr.passed + gr.failed + gr.auto_fixed + gr.warnings
+                        details = f"Evaluated {total} checks..."
+                elif tracked and tracked.status == "completed":
+                    if gr.blocked:
+                        details = f"[red]BLOCKED[/red] - {gr.failed} violations"
+                    elif gr.auto_fixed > 0:
+                        details = f"✓ {gr.passed} passed, {gr.auto_fixed} auto-fixed"
+                    elif gr.failed > 0:
+                        details = f"⚠ {gr.passed} passed, {gr.failed} failed"
+                    else:
+                        details = f"✓ {gr.passed} passed"
 
             steps_table.add_row(
                 status_icon,
@@ -515,6 +618,84 @@ class GenerationProgressDisplay:
                     layer_line.append(f" ({layer.resource_count})", style="dim")
 
                 elements.append(layer_line)
+
+        # Guardrails details (show during evaluation)
+        if self.guardrails and self.current_step == WorkflowStep.EVALUATE_GUARDRAILS:
+            gr = self.guardrails
+            elements.append(Text("\n"))
+            gr_header = Text()
+            gr_header.append("  ", style="")
+            gr_header.append("Guardrails: ", style="bold")
+            total = gr.passed + gr.failed + gr.auto_fixed + gr.warnings
+            gr_header.append(f"{total} evaluated", style="cyan")
+            elements.append(gr_header)
+
+            # Show current evaluation
+            if gr.current_guardrail or gr.current_resource:
+                current_line = Text()
+                current_line.append("    ", style="")
+                current_line.append("● ", style="yellow")
+                if gr.current_guardrail:
+                    current_line.append(gr.current_guardrail, style="yellow")
+                if gr.current_resource:
+                    current_line.append(f" → {gr.current_resource}", style="dim")
+                elements.append(current_line)
+
+            # Show running totals
+            if gr.passed > 0:
+                passed_line = Text()
+                passed_line.append("    ", style="")
+                passed_line.append("✓ ", style="green")
+                passed_line.append(f"{gr.passed} passed", style="green")
+                elements.append(passed_line)
+            if gr.auto_fixed > 0:
+                fixed_line = Text()
+                fixed_line.append("    ", style="")
+                fixed_line.append("🔧 ", style="cyan")
+                fixed_line.append(f"{gr.auto_fixed} auto-fixed", style="cyan")
+                elements.append(fixed_line)
+            if gr.failed > 0:
+                failed_line = Text()
+                failed_line.append("    ", style="")
+                failed_line.append("✗ ", style="red")
+                failed_line.append(f"{gr.failed} failed", style="red")
+                elements.append(failed_line)
+            if gr.warnings > 0:
+                warn_line = Text()
+                warn_line.append("    ", style="")
+                warn_line.append("⚠ ", style="yellow")
+                warn_line.append(f"{gr.warnings} warnings", style="yellow")
+                elements.append(warn_line)
+
+        # Guardrails summary (show after evaluation)
+        if self.guardrails and self.guardrails_enabled and self.current_step not in [
+            WorkflowStep.PARSE_INVENTORY,
+            WorkflowStep.BUILD_RESOURCE_MAP,
+            WorkflowStep.EVALUATE_GUARDRAILS,
+        ]:
+            gr = self.guardrails
+            if gr.blocked:
+                elements.append(Text("\n"))
+                block_line = Text()
+                block_line.append("  ", style="")
+                block_line.append("🛡️ Guardrails: ", style="bold")
+                block_line.append("BLOCKED", style="bold red")
+                block_line.append(f" - {gr.block_reason}", style="red")
+                elements.append(block_line)
+            elif gr.passed > 0 or gr.auto_fixed > 0:
+                elements.append(Text("\n"))
+                summary_line = Text()
+                summary_line.append("  ", style="")
+                summary_line.append("🛡️ Guardrails: ", style="bold")
+                parts = []
+                if gr.passed > 0:
+                    parts.append(f"[green]{gr.passed} passed[/green]")
+                if gr.auto_fixed > 0:
+                    parts.append(f"[cyan]{gr.auto_fixed} auto-fixed[/cyan]")
+                if gr.warnings > 0:
+                    parts.append(f"[yellow]{gr.warnings} warnings[/yellow]")
+                summary_line.append(", ".join(parts))
+                elements.append(summary_line)
 
         # Comparison result
         if self.comparison and self.current_step in [
@@ -609,6 +790,23 @@ class GenerationProgressDisplay:
             coverage = self.comparison.coverage_percentage
             color = "green" if coverage >= 90 else "yellow" if coverage >= 70 else "red"
             table.add_row("Coverage", f"[{color}]{coverage:.1f}%[/{color}]")
+
+        if self.guardrails and self.guardrails_enabled:
+            gr = self.guardrails
+            label = "Best Practices" if self.best_practices_mode else "Guardrails"
+            if gr.blocked:
+                table.add_row(label, f"[red]BLOCKED ({gr.failed} violations)[/red]")
+            else:
+                parts = []
+                if gr.passed > 0:
+                    parts.append(f"[green]{gr.passed} passed[/green]")
+                if gr.auto_fixed > 0:
+                    parts.append(f"[cyan]{gr.auto_fixed} fixed[/cyan]")
+                if gr.warnings > 0:
+                    parts.append(f"[yellow]{gr.warnings} warn[/yellow]")
+                if gr.failed > 0:
+                    parts.append(f"[red]{gr.failed} failed[/red]")
+                table.add_row(label, ", ".join(parts) if parts else "[green]✓[/green]")
 
         self.console.print(table)
         self.console.print()

--- a/src/cli/guardrails.py
+++ b/src/cli/guardrails.py
@@ -7,12 +7,15 @@ from pathlib import Path
 from typing import Optional
 
 import typer
-from rich.console import Console
+from rich.console import Console, Group
+from rich.live import Live
 from rich.table import Table
+from rich.text import Text
 
 from ..guardrails import (
     GuardrailEvaluator,
     GuardrailPolicy,
+    export_builtin_policy_yaml,
     load_builtin_guardrails,
     load_policy,
 )
@@ -21,6 +24,109 @@ from ..guardrails.reporter import format_terminal_report
 from ..snapshot.storage import SnapshotStorage
 
 console = Console()
+
+
+class GuardrailsProgressDisplay:
+    """Simple progress display for guardrails evaluation."""
+
+    def __init__(self, con: Console, total_resources: int, total_guardrails: int) -> None:
+        self.console = con
+        self.total_resources = total_resources
+        self.total_guardrails = total_guardrails
+        self.current_resource = 0
+        self.current_resource_name = ""
+        self.current_guardrail = ""
+        self.passed = 0
+        self.failed = 0
+        self.auto_fixed = 0
+        self.warnings = 0
+        self.live: Optional[Live] = None
+
+    def _build_display(self) -> Group:
+        """Build the Rich display."""
+        elements = []
+
+        # Header line
+        header = Text()
+        header.append("\n🛡️  ", style="bold")
+        header.append("Guardrails Evaluation", style="bold cyan")
+        elements.append(header)
+
+        # Progress line
+        progress_line = Text()
+        progress_line.append("  Resources: ", style="dim")
+        progress_line.append(f"{self.current_resource}/{self.total_resources}", style="cyan")
+        progress_line.append("  Guardrails: ", style="dim")
+        progress_line.append(f"{self.total_guardrails}", style="cyan")
+        elements.append(progress_line)
+        elements.append(Text("\n"))
+
+        # Current evaluation
+        if self.current_resource_name or self.current_guardrail:
+            current_line = Text()
+            current_line.append("  ● ", style="yellow")
+            if self.current_guardrail:
+                current_line.append(self.current_guardrail, style="yellow")
+            if self.current_resource_name:
+                current_line.append(f" → {self.current_resource_name}", style="dim")
+            elements.append(current_line)
+            elements.append(Text("\n"))
+
+        # Counts table
+        counts_line = Text()
+        counts_line.append("  ")
+        counts_line.append(f"✓ {self.passed} passed", style="green")
+        counts_line.append("  ")
+        counts_line.append(f"✗ {self.failed} failed", style="red")
+        if self.auto_fixed > 0:
+            counts_line.append("  ")
+            counts_line.append(f"🔧 {self.auto_fixed} fixed", style="cyan")
+        if self.warnings > 0:
+            counts_line.append("  ")
+            counts_line.append(f"⚠ {self.warnings} warnings", style="yellow")
+        elements.append(counts_line)
+        elements.append(Text("\n"))
+
+        return Group(*elements)
+
+    def update(
+        self,
+        current: int,
+        total: int,
+        guardrail_id: str = "",
+        resource_name: str = "",
+        passed: int = 0,
+        failed: int = 0,
+        auto_fixed: int = 0,
+        warnings: int = 0,
+    ) -> None:
+        """Update progress."""
+        self.current_resource = current
+        self.current_guardrail = guardrail_id
+        self.current_resource_name = resource_name
+        self.passed = passed
+        self.failed = failed
+        self.auto_fixed = auto_fixed
+        self.warnings = warnings
+        if self.live:
+            self.live.update(self._build_display())
+
+    def start(self) -> None:
+        """Start live display."""
+        self.live = Live(
+            self._build_display(),
+            console=self.console,
+            refresh_per_second=4,
+            transient=True,
+        )
+        self.live.start()
+
+    def stop(self) -> None:
+        """Stop live display."""
+        if self.live:
+            self.live.stop()
+            self.live = None
+
 
 # Create the guardrails command group
 guardrails_app = typer.Typer(
@@ -172,15 +278,41 @@ def check(
 
     num_resources = len(resource_objects)
     num_guardrails = len(loaded_policy.guardrails)
-    console.print(
-        f"Evaluating [cyan]{num_resources}[/cyan] resources against [cyan]{num_guardrails}[/cyan] guardrails..."
-    )
-    console.print()
 
-    report = evaluator.evaluate_all(
-        resources=resource_objects,
-        snapshot_name=snapshot_display_name,
-    )
+    # Create progress display
+    progress_display = GuardrailsProgressDisplay(console, num_resources, num_guardrails)
+
+    def progress_callback(
+        current: int,
+        total: int,
+        guardrail_id: str = "",
+        resource_name: str = "",
+        passed: int = 0,
+        failed: int = 0,
+        auto_fixed: int = 0,
+        warnings: int = 0,
+    ) -> None:
+        progress_display.update(
+            current=current,
+            total=total,
+            guardrail_id=guardrail_id,
+            resource_name=resource_name,
+            passed=passed,
+            failed=failed,
+            auto_fixed=auto_fixed,
+            warnings=warnings,
+        )
+
+    # Run evaluation with progress
+    progress_display.start()
+    try:
+        report = evaluator.evaluate_all(
+            resources=resource_objects,
+            snapshot_name=snapshot_display_name,
+            progress_callback=progress_callback,
+        )
+    finally:
+        progress_display.stop()
 
     # Determine exit status
     has_blocking_violations = report.blocked
@@ -495,6 +627,48 @@ def validate_policy_file(
                 action = g.get("action", "UNKNOWN")
                 action_counts[action] = action_counts.get(action, 0) + 1
             console.print(f"  Actions: {', '.join(f'{k}={v}' for k, v in action_counts.items())}")
+
+    raise typer.Exit(0)
+
+
+@guardrails_app.command("export")
+def export_guardrails(
+    output: Optional[str] = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Save to file instead of stdout",
+    ),
+    category: Optional[str] = typer.Option(
+        None,
+        "--category",
+        "-c",
+        help="Filter by category: encryption, network, tagging, logging",
+    ),
+) -> None:
+    """Export built-in guardrails as a standard YAML policy file.
+
+    Outputs the built-in best-practice guardrails in the standard policy
+    format so you can customize them.
+
+    Examples:
+        awsinv guardrails export > my-policy.yaml
+        awsinv guardrails export --output my-policy.yaml
+        awsinv guardrails export --category encryption --output enc-policy.yaml
+    """
+    yaml_content = export_builtin_policy_yaml(category=category)
+
+    if output:
+        output_path = Path(output)
+        try:
+            with open(output_path, "w") as f:
+                f.write(yaml_content)
+            console.print(f"[green]Exported to {output_path}[/green]")
+        except Exception as e:
+            console.print(f"[red]Error:[/red] Failed to write file: {e}")
+            raise typer.Exit(1)
+    else:
+        console.print(yaml_content, highlight=False)
 
     raise typer.Exit(0)
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -5986,6 +5986,11 @@ def generate(
     ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed progress"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show what would be generated without creating files"),
+    no_best_practices: bool = typer.Option(
+        False,
+        "--no-best-practices",
+        help="Disable built-in best-practice guardrails (advisory warnings)",
+    ),
     guardrails: bool = typer.Option(False, "--guardrails", "-g", help="Enable guardrails policy evaluation"),
     guardrails_policy: Optional[str] = typer.Option(
         None,
@@ -6104,29 +6109,57 @@ def generate(
         for rtype, count in sorted(type_counts.items(), key=lambda x: -x[1])[:10]:
             console.print(f"  {rtype}: {count}")
 
-        # Run guardrails evaluation if enabled
-        if guardrails:
-            from ..guardrails import GuardrailEvaluator, GuardrailPolicy, load_builtin_guardrails, load_policy
-            from ..guardrails.models import EvaluationResult
+        # Determine best-practice mode
+        best_practices_enabled = not no_best_practices
+
+        # Run guardrails evaluation if enabled (enforcement or best-practice)
+        if guardrails or best_practices_enabled:
+            import dataclasses
+
+            from ..guardrails import (
+                GuardrailEvaluator,
+                GuardrailPolicy,
+                load_best_practice_guardrails,
+                load_builtin_guardrails,
+                load_policy,
+            )
+            from ..guardrails.models import Action, EvaluationResult
 
             console.print()
-            console.print("[cyan]Guardrails Evaluation:[/cyan]")
+            if guardrails:
+                console.print("[cyan]Guardrails Evaluation:[/cyan]")
+            else:
+                console.print("[cyan]Best Practices (advisory):[/cyan]")
 
             # Load policy
-            if guardrails_policy:
-                policy = load_policy(guardrails_policy, environment=guardrails_env)
+            if guardrails:
+                if guardrails_policy:
+                    policy = load_policy(guardrails_policy, environment=guardrails_env)
+                else:
+                    builtin = load_builtin_guardrails()
+                    policy = GuardrailPolicy(
+                        name="builtin",
+                        version="1.0",
+                        description="Built-in guardrails",
+                        guardrails=builtin,
+                    )
             else:
-                builtin = load_builtin_guardrails()
+                # Best-practice advisory mode
+                bp_guardrails = load_best_practice_guardrails()
+                advisory_guardrails = [
+                    dataclasses.replace(g, action=Action.WARN) for g in bp_guardrails
+                ]
                 policy = GuardrailPolicy(
-                    name="builtin",
+                    name="best-practices",
                     version="1.0",
-                    description="Built-in guardrails",
-                    guardrails=builtin,
+                    description="Built-in best-practice guardrails (advisory)",
+                    guardrails=advisory_guardrails,
                 )
 
             console.print(f"  Policy: {policy.name} v{policy.version}")
             console.print(f"  Guardrails: {len(policy.guardrails)}")
-            console.print(f"  Environment: {guardrails_env}")
+            if guardrails:
+                console.print(f"  Environment: {guardrails_env}")
 
             # Create resource wrappers for evaluation
             class ResourceWrapper:
@@ -6141,43 +6174,45 @@ def generate(
             # Evaluate
             evaluator = GuardrailEvaluator(
                 policy=policy,
-                auto_fix_enabled=guardrails_auto_fix,
+                auto_fix_enabled=guardrails_auto_fix if guardrails else False,
                 environment=guardrails_env,
                 output_format=format,
             )
 
-            report = evaluator.evaluate_all(resource_objects, validate_fixes=True)
+            report = evaluator.evaluate_all(resource_objects, validate_fixes=guardrails)
 
             # Show results
             console.print()
             console.print(f"  [green]Passed:[/green] {report.summary.passed}")
             console.print(f"  [red]Failed:[/red] {report.summary.failed}")
-            console.print(f"  [yellow]Auto-fixed:[/yellow] {report.summary.auto_fixed}")
+            if guardrails:
+                console.print(f"  [yellow]Auto-fixed:[/yellow] {report.summary.auto_fixed}")
 
-            # Show auto-fixes that would be applied
-            auto_fixes = evaluator.get_auto_fixes()
-            if auto_fixes:
-                console.print()
-                console.print("[cyan]Auto-fixes that would be applied:[/cyan]")
-                for resource_id, fixes in list(auto_fixes.items())[:5]:
-                    console.print(f"  {resource_id}:")
-                    for gr_id in fixes.keys():
-                        console.print(f"    - {gr_id}")
-                if len(auto_fixes) > 5:
-                    console.print(f"  ... and {len(auto_fixes) - 5} more")
+            # Show auto-fixes that would be applied (enforcement mode only)
+            if guardrails:
+                auto_fixes = evaluator.get_auto_fixes()
+                if auto_fixes:
+                    console.print()
+                    console.print("[cyan]Auto-fixes that would be applied:[/cyan]")
+                    for resource_id, fixes in list(auto_fixes.items())[:5]:
+                        console.print(f"  {resource_id}:")
+                        for gr_id in fixes.keys():
+                            console.print(f"    - {gr_id}")
+                    if len(auto_fixes) > 5:
+                        console.print(f"  ... and {len(auto_fixes) - 5} more")
 
-            # Show conflicts if any
-            if report.fix_conflicts:
-                console.print()
-                console.print("[red]Fix Conflicts Detected:[/red]")
-                for conflict in report.fix_conflicts[:5]:
-                    console.print(f"  {conflict.original_guardrail_id} -> {conflict.conflicting_guardrail_id}")
-                    console.print(f"    {conflict.description[:80]}...")
+                # Show conflicts if any
+                if report.fix_conflicts:
+                    console.print()
+                    console.print("[red]Fix Conflicts Detected:[/red]")
+                    for conflict in report.fix_conflicts[:5]:
+                        console.print(f"  {conflict.original_guardrail_id} -> {conflict.conflicting_guardrail_id}")
+                        console.print(f"    {conflict.description[:80]}...")
 
-            # Show blocking status
-            if report.blocked:
-                console.print()
-                console.print(f"[red]Would be BLOCKED:[/red] {report.block_reason}")
+                # Show blocking status
+                if report.blocked:
+                    console.print()
+                    console.print(f"[red]Would be BLOCKED:[/red] {report.block_reason}")
 
         console.print()
         console.print(f"[cyan]Output directory:[/cyan] {output}")
@@ -6191,6 +6226,11 @@ def generate(
     source_name = from_file if from_file else snapshot_name or ""
     progress.set_source(source_name, output)
     progress.set_output_format(format)
+
+    # Enable guardrails tracking if any guardrails mode is active
+    best_practices_enabled = not no_best_practices
+    if guardrails or best_practices_enabled:
+        progress.enable_guardrails(best_practices_mode=not guardrails and best_practices_enabled)
 
     # Map node names to workflow steps (common nodes + format-specific)
     node_to_step = {
@@ -6285,14 +6325,39 @@ def generate(
         elif event == "guardrails_progress":
             current = data.get("current", 0)
             total = data.get("total", 0)
-            progress.set_activity(f"Evaluating guardrails: {current}/{total}")
+            guardrail_id = data.get("guardrail_id", "")
+            resource_name = data.get("resource_name", "")
+            passed = data.get("passed", 0)
+            failed = data.get("failed", 0)
+            auto_fixed = data.get("auto_fixed", 0)
+            warnings = data.get("warnings", 0)
+            progress.update_guardrails_progress(
+                current_guardrail=guardrail_id,
+                current_resource=resource_name,
+                passed=passed,
+                failed=failed,
+                auto_fixed=auto_fixed,
+                warnings=warnings,
+                total=total,
+            )
 
         elif event == "guardrails_complete":
             passed = data.get("passed", 0)
             failed = data.get("failed", 0)
+            auto_fixed = data.get("auto_fixed", 0)
+            warnings = data.get("warnings", 0)
             blocked = data.get("blocked", False)
+            block_reason = data.get("block_reason", "")
+            progress.set_guardrails_result(
+                passed=passed,
+                failed=failed,
+                auto_fixed=auto_fixed,
+                warnings=warnings,
+                blocked=blocked,
+                block_reason=block_reason,
+            )
             if blocked:
-                progress.set_activity(f"Guardrails: {failed} violations (blocked)")
+                progress.set_activity(f"Guardrails blocked: {block_reason}")
             else:
                 progress.set_activity(f"Guardrails: {passed} passed, {failed} failed")
 
@@ -6312,6 +6377,7 @@ def generate(
                 guardrails_environment=guardrails_env,
                 guardrails_strict=guardrails_strict,
                 guardrails_auto_fix=guardrails_auto_fix,
+                best_practices_enabled=best_practices_enabled,
             )
         else:
             # CDK generation (cdk-typescript or cdk-python)
@@ -6328,6 +6394,7 @@ def generate(
                 guardrails_environment=guardrails_env,
                 guardrails_strict=guardrails_strict,
                 guardrails_auto_fix=guardrails_auto_fix,
+                best_practices_enabled=best_practices_enabled,
             )
 
         if result.success:
@@ -6339,12 +6406,18 @@ def generate(
     # Print final summary
     progress.print_final_summary(result.success)
 
-    # Display guardrails report if enabled and blocked
-    if result.guardrails_blocked and result.guardrails_report:
-        from src.guardrails.reporter import format_terminal_report
+    # Display guardrails report if blocked (enforcement) or if best practices had findings
+    if result.guardrails_report:
+        report_data = result.guardrails_report
+        has_findings = (
+            report_data.get("summary", {}).get("failed", 0) > 0
+            or report_data.get("summary", {}).get("warnings", 0) > 0
+        )
+        if result.guardrails_blocked or has_findings:
+            from src.guardrails.reporter import format_terminal_report
 
-        console.print()
-        format_terminal_report(result.guardrails_report, console)
+            console.print()
+            format_terminal_report(report_data, console)
 
     # Save guardrails report to file if requested
     if guardrails_report and result.guardrails_report:

--- a/src/generate/cdk_generator.py
+++ b/src/generate/cdk_generator.py
@@ -68,6 +68,7 @@ class CDKGenerator:
         guardrails_environment: str = "default",
         guardrails_strict: bool = False,
         guardrails_auto_fix: bool = True,
+        best_practices_enabled: bool = True,
     ):
         """Initialize generator.
 
@@ -83,6 +84,7 @@ class CDKGenerator:
             guardrails_environment: Environment for policy overrides
             guardrails_strict: Enable strict mode (any violation blocks)
             guardrails_auto_fix: Enable AI auto-fix for AUTO-FIX guardrails
+            best_practices_enabled: Enable advisory best-practice guardrails
         """
         self.output_dir = output_dir
         self.output_format = output_format
@@ -93,6 +95,7 @@ class CDKGenerator:
         self.guardrails_environment = guardrails_environment
         self.guardrails_strict = guardrails_strict
         self.guardrails_auto_fix = guardrails_auto_fix
+        self.best_practices_enabled = best_practices_enabled
 
         base_config = GenerationConfig.from_env()
 
@@ -153,6 +156,7 @@ class CDKGenerator:
             "errors": [],
             "messages": [],
             # Guardrails fields
+            "best_practices_enabled": self.best_practices_enabled,
             "guardrails_enabled": self.guardrails_enabled,
             "guardrails_policy_path": self.guardrails_policy_path,
             "guardrails_environment": self.guardrails_environment,
@@ -524,6 +528,7 @@ def generate_cdk(
     guardrails_environment: str = "default",
     guardrails_strict: bool = False,
     guardrails_auto_fix: bool = True,
+    best_practices_enabled: bool = True,
 ) -> GenerationResult:
     """Generate CDK from a snapshot or export file.
 
@@ -541,6 +546,7 @@ def generate_cdk(
         guardrails_environment: Environment for policy overrides
         guardrails_strict: Enable strict mode (any violation blocks)
         guardrails_auto_fix: Enable AI auto-fix for AUTO-FIX guardrails
+        best_practices_enabled: Enable advisory best-practice guardrails
 
     Returns:
         GenerationResult
@@ -557,5 +563,6 @@ def generate_cdk(
         guardrails_environment=guardrails_environment,
         guardrails_strict=guardrails_strict,
         guardrails_auto_fix=guardrails_auto_fix,
+        best_practices_enabled=best_practices_enabled,
     )
     return generator.run(snapshot_name=snapshot_name, input_file=input_file)

--- a/src/generate/nodes/evaluate_guardrails.py
+++ b/src/generate/nodes/evaluate_guardrails.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from typing import Any, Dict, Optional
 
@@ -30,7 +31,8 @@ def evaluate_guardrails(state: GenerationState) -> Dict[str, Any]:
 
     Reads from state:
         - resources: List[TrackedResource] - Parsed resources
-        - guardrails_enabled: bool - Whether guardrails are enabled
+        - best_practices_enabled: bool - Whether best-practice advisory mode is on
+        - guardrails_enabled: bool - Whether full guardrails enforcement is enabled
         - guardrails_policy_path: str - Path to policy file
         - guardrails_environment: str - Environment for overrides
         - guardrails_strict: bool - Fail on any violation
@@ -45,9 +47,11 @@ def evaluate_guardrails(state: GenerationState) -> Dict[str, Any]:
     Returns:
         State updates dictionary.
     """
-    # Check if guardrails are enabled
     guardrails_enabled = state.get("guardrails_enabled", False)
-    if not guardrails_enabled:
+    best_practices_enabled = state.get("best_practices_enabled", True)
+
+    # Skip entirely if both are disabled
+    if not guardrails_enabled and not best_practices_enabled:
         return {
             "guardrails_blocked": False,
             "guardrails_report": None,
@@ -55,8 +59,8 @@ def evaluate_guardrails(state: GenerationState) -> Dict[str, Any]:
         }
 
     # Import here to avoid circular imports and loading if not needed
-    from src.guardrails import GuardrailEvaluator, load_builtin_guardrails, load_policy
-    from src.guardrails.models import EvaluationResult, GuardrailPolicy
+    from src.guardrails import GuardrailEvaluator, load_best_practice_guardrails, load_builtin_guardrails, load_policy
+    from src.guardrails.models import Action, EvaluationResult, GuardrailPolicy
 
     resources = state.get("resources", [])
     policy_path = state.get("guardrails_policy_path")
@@ -66,42 +70,81 @@ def evaluate_guardrails(state: GenerationState) -> Dict[str, Any]:
     snapshot_name = state.get("snapshot_name", "")
     output_format = state.get("output_format", "terraform")
 
-    emit_progress("guardrails_start", {"total_resources": len(resources)})
+    emit_progress("guardrails_start", {
+        "total_resources": len(resources),
+        "mode": "enforcement" if guardrails_enabled else "best_practices",
+    })
 
-    # Load policy
-    if policy_path:
-        policy = load_policy(policy_path, environment=environment)
+    if guardrails_enabled:
+        # Full enforcement mode (existing behavior)
+        if policy_path:
+            policy = load_policy(policy_path, environment=environment)
+        else:
+            builtin = load_builtin_guardrails()
+            policy = GuardrailPolicy(
+                name="builtin",
+                version="1.0",
+                description="Built-in guardrails",
+                guardrails=builtin,
+            )
+
+        # Get Bedrock client for auto-fix if enabled
+        bedrock_client = None
+        if auto_fix_enabled:
+            bedrock_client = _get_bedrock_client()
+            if bedrock_client:
+                logger.info("Auto-fix enabled with Bedrock AI")
+            else:
+                logger.warning("Auto-fix requested but Bedrock client unavailable")
+
+        evaluator = GuardrailEvaluator(
+            policy=policy,
+            auto_fix_enabled=auto_fix_enabled and bedrock_client is not None,
+            bedrock_client=bedrock_client,
+            environment=environment,
+            output_format=output_format,
+        )
     else:
-        # Use built-in guardrails
-        builtin = load_builtin_guardrails()
+        # Best-practice advisory mode: load only best-practice guardrails,
+        # downgrade all actions to WARN, disable auto-fix
+        bp_guardrails = load_best_practice_guardrails()
+        advisory_guardrails = [
+            dataclasses.replace(g, action=Action.WARN) for g in bp_guardrails
+        ]
         policy = GuardrailPolicy(
-            name="builtin",
+            name="best-practices",
             version="1.0",
-            description="Built-in guardrails",
-            guardrails=builtin,
+            description="Built-in best-practice guardrails (advisory)",
+            guardrails=advisory_guardrails,
+        )
+        evaluator = GuardrailEvaluator(
+            policy=policy,
+            auto_fix_enabled=False,
+            environment=environment,
+            output_format=output_format,
         )
 
-    # Get Bedrock client for auto-fix if enabled
-    bedrock_client = None
-    if auto_fix_enabled:
-        bedrock_client = _get_bedrock_client()
-        if bedrock_client:
-            logger.info("Auto-fix enabled with Bedrock AI")
-        else:
-            logger.warning("Auto-fix requested but Bedrock client unavailable")
-
-    # Create evaluator
-    evaluator = GuardrailEvaluator(
-        policy=policy,
-        auto_fix_enabled=auto_fix_enabled and bedrock_client is not None,
-        bedrock_client=bedrock_client,
-        environment=environment,
-        output_format=output_format,
-    )
-
-    # Progress callback
-    def progress_callback(current: int, total: int) -> None:
-        emit_progress("guardrails_progress", {"current": current, "total": total})
+    # Progress callback with rich data
+    def progress_callback(
+        current: int,
+        total: int,
+        guardrail_id: str = "",
+        resource_name: str = "",
+        passed: int = 0,
+        failed: int = 0,
+        auto_fixed: int = 0,
+        warnings: int = 0,
+    ) -> None:
+        emit_progress("guardrails_progress", {
+            "current": current,
+            "total": total,
+            "guardrail_id": guardrail_id,
+            "resource_name": resource_name,
+            "passed": passed,
+            "failed": failed,
+            "auto_fixed": auto_fixed,
+            "warnings": warnings,
+        })
 
     # Evaluate all resources
     report = evaluator.evaluate_all(
@@ -113,18 +156,18 @@ def evaluate_guardrails(state: GenerationState) -> Dict[str, Any]:
     # Determine if blocked
     blocked = False
 
-    if strict_mode:
-        # In strict mode, any failure blocks
-        failed_evals = [e for e in report.evaluations if e.result == EvaluationResult.FAIL]
-        if failed_evals:
-            blocked = True
-            report.blocked = True
-            report.block_reason = f"Strict mode: {len(failed_evals)} violations found"
-    else:
-        # Normal mode: only CRITICAL/HIGH with BLOCK action blocks
-        blocked = report.blocked
+    if guardrails_enabled:
+        # Full enforcement: check blocking logic
+        if strict_mode:
+            failed_evals = [e for e in report.evaluations if e.result == EvaluationResult.FAIL]
+            if failed_evals:
+                blocked = True
+                report.blocked = True
+                report.block_reason = f"Strict mode: {len(failed_evals)} violations found"
+        else:
+            blocked = report.blocked
+    # Best-practice mode never blocks
 
-    # Get auto-fixes (placeholder for future implementation)
     auto_fixes = evaluator.get_auto_fixes()
 
     emit_progress(
@@ -133,7 +176,10 @@ def evaluate_guardrails(state: GenerationState) -> Dict[str, Any]:
             "passed": report.summary.passed,
             "failed": report.summary.failed,
             "auto_fixed": report.summary.auto_fixed,
+            "warnings": report.summary.warnings,
             "blocked": blocked,
+            "block_reason": report.block_reason if blocked else "",
+            "mode": "enforcement" if guardrails_enabled else "best_practices",
         },
     )
 

--- a/src/generate/state.py
+++ b/src/generate/state.py
@@ -68,6 +68,7 @@ class GenerationState(TypedDict, total=False):
     messages: Annotated[List[Dict[str, Any]], add]
 
     # Guardrails fields
+    best_practices_enabled: bool  # Whether best-practice advisory guardrails are enabled
     guardrails_enabled: bool  # Whether guardrail evaluation is enabled
     guardrails_policy_path: Optional[str]  # Path to guardrail policy file
     guardrails_environment: str  # Environment name for policy overrides (default: "default")

--- a/src/generate/terraform_generator.py
+++ b/src/generate/terraform_generator.py
@@ -93,6 +93,7 @@ class TerraformGenerator:
         guardrails_environment: str = "default",
         guardrails_strict: bool = False,
         guardrails_auto_fix: bool = True,
+        best_practices_enabled: bool = True,
     ):
         """Initialize generator.
 
@@ -106,6 +107,7 @@ class TerraformGenerator:
             guardrails_environment: Environment for policy overrides
             guardrails_strict: Enable strict mode (any violation blocks)
             guardrails_auto_fix: Enable AI auto-fix for AUTO-FIX guardrails
+            best_practices_enabled: Enable advisory best-practice guardrails
         """
         self.output_dir = output_dir
         self.progress_callback = progress_callback
@@ -114,6 +116,7 @@ class TerraformGenerator:
         self.guardrails_environment = guardrails_environment
         self.guardrails_strict = guardrails_strict
         self.guardrails_auto_fix = guardrails_auto_fix
+        self.best_practices_enabled = best_practices_enabled
 
         base_config = GenerationConfig.from_env()
 
@@ -169,6 +172,7 @@ class TerraformGenerator:
             "errors": [],
             "messages": [],
             # Guardrails fields
+            "best_practices_enabled": self.best_practices_enabled,
             "guardrails_enabled": self.guardrails_enabled,
             "guardrails_policy_path": self.guardrails_policy_path,
             "guardrails_environment": self.guardrails_environment,
@@ -431,6 +435,7 @@ def generate_terraform(
     guardrails_environment: str = "default",
     guardrails_strict: bool = False,
     guardrails_auto_fix: bool = True,
+    best_practices_enabled: bool = True,
 ) -> GenerationResult:
     """Generate Terraform from a snapshot or export file.
 
@@ -446,6 +451,7 @@ def generate_terraform(
         guardrails_environment: Environment for policy overrides
         guardrails_strict: Enable strict mode (any violation blocks)
         guardrails_auto_fix: Enable AI auto-fix for AUTO-FIX guardrails
+        best_practices_enabled: Enable advisory best-practice guardrails
 
     Returns:
         GenerationResult
@@ -460,5 +466,6 @@ def generate_terraform(
         guardrails_environment=guardrails_environment,
         guardrails_strict=guardrails_strict,
         guardrails_auto_fix=guardrails_auto_fix,
+        best_practices_enabled=best_practices_enabled,
     )
     return generator.run(snapshot_name=snapshot_name, input_file=input_file)

--- a/src/guardrails/__init__.py
+++ b/src/guardrails/__init__.py
@@ -10,7 +10,7 @@ from .generator import (
     generate_guardrails_batch,
     guardrail_to_yaml,
 )
-from .loader import load_builtin_guardrails, load_policy
+from .loader import export_builtin_policy_yaml, load_best_practice_guardrails, load_builtin_guardrails, load_policy
 from .models import (
     Action,
     AutoFixError,
@@ -58,6 +58,8 @@ __all__ = [
     # Loader functions
     "load_policy",
     "load_builtin_guardrails",
+    "load_best_practice_guardrails",
+    "export_builtin_policy_yaml",
     # Formula evaluation
     "evaluate_formula",
     "validate_formula",

--- a/src/guardrails/builtin/encryption.yaml
+++ b/src/guardrails/builtin/encryption.yaml
@@ -4,6 +4,7 @@ guardrails:
     short_description: "S3 bucket must have encryption at rest"
     severity: CRITICAL
     action: AUTO-FIX
+    best_practice: true
     applies_to:
       - s3:bucket
     condition:
@@ -29,6 +30,7 @@ guardrails:
     short_description: "RDS instance must have encryption at rest"
     severity: CRITICAL
     action: BLOCK
+    best_practice: true
     applies_to:
       - rds:db
       - rds:cluster
@@ -52,6 +54,7 @@ guardrails:
     short_description: "EBS volume must have encryption"
     severity: CRITICAL
     action: AUTO-FIX
+    best_practice: true
     applies_to:
       - ec2:volume
     condition:
@@ -74,6 +77,7 @@ guardrails:
     short_description: "DynamoDB table must have encryption"
     severity: HIGH
     action: AUTO-FIX
+    best_practice: true
     applies_to:
       - dynamodb:table
     condition:
@@ -93,6 +97,7 @@ guardrails:
     short_description: "Secrets Manager secret must use encryption"
     severity: HIGH
     action: AUTO-FIX
+    best_practice: true
     applies_to:
       - secretsmanager:secret
     condition:

--- a/src/guardrails/builtin/logging.yaml
+++ b/src/guardrails/builtin/logging.yaml
@@ -4,6 +4,7 @@ guardrails:
     short_description: "S3 bucket must have access logging enabled"
     severity: HIGH
     action: AUTO-FIX
+    best_practice: true
     applies_to:
       - s3:bucket
     condition:
@@ -26,6 +27,7 @@ guardrails:
     short_description: "CloudTrail must be enabled for API logging"
     severity: CRITICAL
     action: WARN
+    best_practice: true
     applies_to:
       - cloudtrail:trail
     condition:
@@ -46,6 +48,7 @@ guardrails:
     short_description: "Lambda function must have logging configured"
     severity: MEDIUM
     action: AUTO-FIX
+    best_practice: true
     applies_to:
       - lambda:function
     condition:

--- a/src/guardrails/builtin/network.yaml
+++ b/src/guardrails/builtin/network.yaml
@@ -4,6 +4,7 @@ guardrails:
     short_description: "Security group must not allow SSH from 0.0.0.0/0"
     severity: CRITICAL
     action: BLOCK
+    best_practice: true
     applies_to:
       - ec2:security-group
     condition:
@@ -29,6 +30,7 @@ guardrails:
     short_description: "Security group must not allow RDP from 0.0.0.0/0"
     severity: CRITICAL
     action: BLOCK
+    best_practice: true
     applies_to:
       - ec2:security-group
     condition:
@@ -49,6 +51,7 @@ guardrails:
     short_description: "Security group must not allow all traffic from 0.0.0.0/0"
     severity: CRITICAL
     action: BLOCK
+    best_practice: true
     applies_to:
       - ec2:security-group
     condition:
@@ -68,6 +71,7 @@ guardrails:
     short_description: "VPC must have flow logs enabled"
     severity: HIGH
     action: WARN
+    best_practice: true
     applies_to:
       - ec2:vpc
     condition:
@@ -88,6 +92,7 @@ guardrails:
     short_description: "Load balancer must have deletion protection"
     severity: MEDIUM
     action: AUTO-FIX
+    best_practice: true
     applies_to:
       - elasticloadbalancing:loadbalancer
     condition:

--- a/src/guardrails/builtin/tagging.yaml
+++ b/src/guardrails/builtin/tagging.yaml
@@ -4,6 +4,7 @@ guardrails:
     short_description: "All resources must have required tags"
     severity: HIGH
     action: AUTO-FIX
+    best_practice: true
     applies_to:
       - "*"
     condition:
@@ -32,6 +33,7 @@ guardrails:
     short_description: "Resource must have Environment tag"
     severity: HIGH
     action: AUTO-FIX
+    best_practice: true
     applies_to:
       - "*"
     condition:
@@ -53,6 +55,7 @@ guardrails:
     short_description: "Resource must have Owner tag"
     severity: MEDIUM
     action: AUTO-FIX
+    best_practice: true
     applies_to:
       - "*"
     condition:

--- a/src/guardrails/evaluator.py
+++ b/src/guardrails/evaluator.py
@@ -377,7 +377,7 @@ class GuardrailEvaluator:
         self,
         resources: List[Any],
         snapshot_name: str = "",
-        progress_callback: Optional[Callable[[int, int], None]] = None,
+        progress_callback: Optional[Callable[..., None]] = None,
         validate_fixes: bool = True,
     ) -> GuardrailReport:
         """Evaluate all resources against the policy.
@@ -385,7 +385,11 @@ class GuardrailEvaluator:
         Args:
             resources: List of TrackedResource objects.
             snapshot_name: Name of the source snapshot.
-            progress_callback: Optional callback(current, total) for progress.
+            progress_callback: Optional callback for progress updates.
+                Supports two signatures:
+                - Simple: callback(current, total)
+                - Rich: callback(current, total, **kwargs) with guardrail_id, resource_name,
+                        passed, failed, auto_fixed, warnings
             validate_fixes: Whether to validate that fixes don't cause conflicts.
 
         Returns:
@@ -407,14 +411,48 @@ class GuardrailEvaluator:
 
         all_evaluations: List[GuardrailEvaluation] = []
         total = len(resources)
+        passed_count = 0
+        failed_count = 0
+        auto_fixed_count = 0
+        warnings_count = 0
+
         for i, resource in enumerate(resources):
+            resource_name = getattr(resource, "name", str(i))
             evaluations = self.evaluate_resource(resource)
+
+            # Track last guardrail evaluated for this resource
+            last_guardrail_id = ""
             for evaluation in evaluations:
                 report.add_evaluation(evaluation)
                 all_evaluations.append(evaluation)
+                last_guardrail_id = evaluation.guardrail_id
+
+                # Track counts
+                if evaluation.result == EvaluationResult.PASS:
+                    passed_count += 1
+                elif evaluation.result == EvaluationResult.FAIL:
+                    if evaluation.severity in (Severity.LOW, Severity.INFO):
+                        warnings_count += 1
+                    else:
+                        failed_count += 1
+                elif evaluation.result == EvaluationResult.AUTO_FIXED:
+                    auto_fixed_count += 1
 
             if progress_callback:
-                progress_callback(i + 1, total)
+                try:
+                    # Try rich callback signature first
+                    progress_callback(
+                        i + 1, total,
+                        guardrail_id=last_guardrail_id,
+                        resource_name=resource_name,
+                        passed=passed_count,
+                        failed=failed_count,
+                        auto_fixed=auto_fixed_count,
+                        warnings=warnings_count,
+                    )
+                except TypeError:
+                    # Fall back to simple signature
+                    progress_callback(i + 1, total)
 
         # Check for blocking violations
         blocking_violations = report.get_blocking_violations()

--- a/src/guardrails/loader.py
+++ b/src/guardrails/loader.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import yaml
+
+import io
 
 from .models import (
     Action,
@@ -119,6 +121,7 @@ def _guardrail_to_dict(guardrail: Guardrail) -> Dict[str, Any]:
         "ai_context": guardrail.ai_context,
         "enabled": guardrail.enabled,
         "tags": guardrail.tags,
+        "best_practice": guardrail.best_practice,
     }
 
     # Add condition or AI rule (mutually exclusive)
@@ -246,6 +249,7 @@ def _parse_guardrail(g_dict: Dict[str, Any]) -> Guardrail:
         ai_context=g_dict.get("ai_context", ""),
         enabled=g_dict.get("enabled", True),
         tags=g_dict.get("tags", []),
+        best_practice=g_dict.get("best_practice", False),
     )
 
 
@@ -272,3 +276,47 @@ def _parse_override(o_dict: Dict[str, Any]) -> PolicyOverride:
         action=action,
         enabled=o_dict.get("enabled"),
     )
+
+
+def load_best_practice_guardrails() -> List[Guardrail]:
+    """Load only built-in guardrails marked as best_practice.
+
+    Returns:
+        List of Guardrail objects where best_practice=True.
+    """
+    return [g for g in load_builtin_guardrails() if g.best_practice]
+
+
+def export_builtin_policy_yaml(category: Optional[str] = None) -> str:
+    """Export built-in guardrails as a standard policy YAML string.
+
+    Args:
+        category: Optional category filter (e.g., "encryption", "network").
+
+    Returns:
+        YAML string in standard policy format.
+    """
+    guardrails = load_builtin_guardrails()
+
+    if category:
+        cat_upper = category.upper()
+        # Match category abbreviation in ID (e.g., GR-ENC-001 -> ENC matches "encryption")
+        category_map: Dict[str, str] = {
+            "encryption": "ENC",
+            "network": "NET",
+            "tagging": "TAG",
+            "logging": "LOG",
+        }
+        abbrev = category_map.get(category.lower(), cat_upper)
+        guardrails = [g for g in guardrails if f"-{abbrev}-" in g.id]
+
+    policy_dict: Dict[str, Any] = {
+        "name": "builtin-best-practices",
+        "version": "1.0",
+        "description": "Built-in best-practice guardrails exported for customization",
+        "guardrails": [_guardrail_to_dict(g) for g in guardrails],
+    }
+
+    stream = io.StringIO()
+    yaml.dump(policy_dict, stream, default_flow_style=False, sort_keys=False)
+    return stream.getvalue()

--- a/src/guardrails/models.py
+++ b/src/guardrails/models.py
@@ -122,6 +122,7 @@ class Guardrail:
     ai_context: str = ""  # Context for AI auto-fix
     enabled: bool = True
     tags: List[str] = field(default_factory=list)
+    best_practice: bool = False
 
     def is_ai_rule(self) -> bool:
         """Check if this guardrail uses AI evaluation."""

--- a/tests/unit/generate/test_evaluate_guardrails.py
+++ b/tests/unit/generate/test_evaluate_guardrails.py
@@ -27,6 +27,7 @@ class TestEvaluateGuardrailsNode:
 
         state = {
             "guardrails_enabled": False,
+            "best_practices_enabled": False,
             "resources": [self._create_mock_resource()],
             "snapshot_name": "test-snapshot",
         }
@@ -36,6 +37,32 @@ class TestEvaluateGuardrailsNode:
         # Should skip guardrails and return unchanged state
         assert result.get("guardrails_blocked") is False
         assert result.get("guardrails_report") is None
+
+    def test_evaluate_best_practices_mode(self) -> None:
+        """Best-practice mode runs advisory checks (WARN only, never blocks)."""
+        from src.generate.nodes.evaluate_guardrails import evaluate_guardrails
+
+        # Resource without encryption - would be BLOCK in enforcement mode
+        resource = self._create_mock_resource(config={})
+
+        state = {
+            "guardrails_enabled": False,
+            "best_practices_enabled": True,
+            "resources": [resource],
+            "snapshot_name": "test-snapshot",
+            "output_format": "terraform",
+        }
+
+        result = evaluate_guardrails(state)
+
+        # Should NOT be blocked (best practices never block)
+        assert result.get("guardrails_blocked") is False
+        # But should have a report with evaluations
+        assert result.get("guardrails_report") is not None
+        report = result["guardrails_report"]
+        # All actions should be WARN in best-practice mode
+        for evaluation in report.get("evaluations", []):
+            assert evaluation["action"] == "WARN"
 
     def test_evaluate_guardrails_no_resources(self) -> None:
         from src.generate.nodes.evaluate_guardrails import evaluate_guardrails


### PR DESCRIPTION
## Summary
- Add built-in best-practice guardrails that run automatically during `generate` (no `--guardrails` flag needed)
- Best practices are advisory only (WARN action, never block) -- full enforcement mode continues to work as before
- Add `guardrails export` subcommand to export built-in guardrails as standard YAML policy for customization
- Bump version to 1.3.0

Closes #83

## Test plan
- [x] `pytest tests/unit/guardrails/` - all pass
- [x] `pytest tests/unit/generate/` - all pass (including new best-practice test)
- [x] `pytest tests/unit/cli/` - all pass
- [ ] Manual: `awsinv generate terraform --dry-run my-snapshot` shows best-practice warnings
- [ ] Manual: `awsinv generate terraform --dry-run --no-best-practices my-snapshot` skips guardrails
- [ ] Manual: `awsinv guardrails export` outputs valid YAML policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)