### PR TITLE
fix(guardrails): read raw_config from snapshot Resource objects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws-inventory-manager"
-version = "1.3.0"
+version = "1.3.1"
 description = "AWS Resource Inventory Management & Delta Tracking CLI tool"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/cli/guardrails.py
+++ b/src/cli/guardrails.py
@@ -243,10 +243,10 @@ def check(
             # Create a simple object with required attributes
             class ResourceWrapper:
                 def __init__(self, data: dict):
-                    self.resource_type = data.get("resource_type", "unknown")
+                    self.resource_type = data.get("resource_type", data.get("type", "unknown"))
                     self.name = data.get("name", "unknown")
                     self.arn = data.get("arn", "")
-                    self.config = data.get("config", {})
+                    self.config = data.get("config", data.get("raw_config", {}))
 
             resource_objects.append(ResourceWrapper(r))
         else:

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -6164,10 +6164,10 @@ def generate(
             # Create resource wrappers for evaluation
             class ResourceWrapper:
                 def __init__(self, data: dict):
-                    self.resource_type = data.get("resource_type", "unknown")
+                    self.resource_type = data.get("resource_type", data.get("type", "unknown"))
                     self.name = data.get("name", "unknown")
                     self.arn = data.get("arn", "")
-                    self.config = data.get("config", {})
+                    self.config = data.get("config", data.get("raw_config", {}))
 
             resource_objects = [ResourceWrapper(r) if isinstance(r, dict) else r for r in resources]
 

--- a/src/guardrails/evaluator.py
+++ b/src/guardrails/evaluator.py
@@ -186,7 +186,11 @@ class GuardrailEvaluator:
         resource_type = getattr(resource, "resource_type", "")
         resource_name = getattr(resource, "name", "")
         resource_arn = getattr(resource, "arn", "")
-        resource_config = getattr(resource, "config", {}) or {}
+        # Support .config (TrackedResource, test mocks) and .raw_config (snapshot Resource)
+        resource_config = getattr(resource, "config", None)
+        if resource_config is None:
+            resource_config = getattr(resource, "raw_config", None) or {}
+
 
         for guardrail in self._guardrails:
             # Skip disabled guardrails


### PR DESCRIPTION
## Summary
- Fix evaluator to fall back to `raw_config` when `config` attribute is None (snapshot `Resource` model)
- Fix `ResourceWrapper` in CLI to handle `raw_config` and `type` field names
- Bump version to 1.3.1

Fixes #85

## Test plan
- [x] All unit tests pass
- [x] Manual: `awsinv guardrails check calvinware-test` now shows real findings (26 passed, 952 blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)