### PR TITLE
Validate resource config data before guardrails evaluation

### DIFF
--- a/src/cli/guardrails.py
+++ b/src/cli/guardrails.py
@@ -128,6 +128,43 @@ class GuardrailsProgressDisplay:
             self.live = None
 
 
+def _warn_missing_config(resources: list, con: Console) -> int:
+    """Check resources for missing config data and warn/error accordingly.
+
+    Returns count of resources missing config.
+    """
+    total = len(resources)
+    if total == 0:
+        return 0
+
+    missing = 0
+    for r in resources:
+        config = getattr(r, "config", None)
+        raw_config = getattr(r, "raw_config", None)
+        has_config = (config is not None and config != {}) or (raw_config is not None and raw_config != {})
+        if not has_config:
+            missing += 1
+
+    if missing == 0:
+        return 0
+
+    if missing == total:
+        con.print(
+            f"[red]Error:[/red] {missing} of {total} resources have no configuration data (config/raw_config).\n"
+            "Guardrails cannot evaluate resources without configuration data.\n"
+            "\nIf using a snapshot, re-take it with the latest version:\n"
+            "  awsinv snapshot <name>\n"
+            "\nIf using --from-file, ensure resources include a \"config\" or \"raw_config\" key."
+        )
+        raise typer.Exit(1)
+
+    con.print(
+        f"[yellow]Warning:[/yellow] {missing} of {total} resources have no configuration data "
+        "and will be skipped by guardrails."
+    )
+    return missing
+
+
 # Create the guardrails command group
 guardrails_app = typer.Typer(
     name="guardrails",
@@ -251,6 +288,8 @@ def check(
             resource_objects.append(ResourceWrapper(r))
         else:
             resource_objects.append(r)
+
+    _warn_missing_config(resource_objects, console)
 
     # Load policy
     if policy:

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -6171,6 +6171,10 @@ def generate(
 
             resource_objects = [ResourceWrapper(r) if isinstance(r, dict) else r for r in resources]
 
+            from .guardrails import _warn_missing_config
+
+            _warn_missing_config(resource_objects, console)
+
             # Evaluate
             evaluator = GuardrailEvaluator(
                 policy=policy,

--- a/tests/unit/cli/test_guardrails_commands.py
+++ b/tests/unit/cli/test_guardrails_commands.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import click
+import pytest
+from rich.console import Console
 from typer.testing import CliRunner
 
+from src.cli.guardrails import _warn_missing_config
 from src.cli.main import app
 
 runner = CliRunner()
@@ -40,7 +44,7 @@ class TestGuardrailsCheckCommand:
         """Check command returns 0 when no violations found."""
         # Setup mocks - return object with resources attribute
         mock_snapshot = MagicMock()
-        mock_snapshot.resources = [{"resource_type": "s3:bucket", "name": "test", "config": {}}]
+        mock_snapshot.resources = [{"resource_type": "s3:bucket", "name": "test", "config": {"BucketName": "test"}}]
         mock_storage = MagicMock()
         mock_storage.load_snapshot.return_value = mock_snapshot
         mock_storage_class.return_value = mock_storage
@@ -81,7 +85,7 @@ class TestGuardrailsCheckCommand:
 
         # Setup mocks - return object with resources attribute
         mock_snapshot = MagicMock()
-        mock_snapshot.resources = [{"resource_type": "s3:bucket", "name": "test", "config": {}}]
+        mock_snapshot.resources = [{"resource_type": "s3:bucket", "name": "test", "config": {"BucketName": "test"}}]
         mock_storage = MagicMock()
         mock_storage.load_snapshot.return_value = mock_snapshot
         mock_storage_class.return_value = mock_storage
@@ -183,7 +187,7 @@ guardrails: []
 
         # Setup mocks - return object with resources attribute
         mock_snapshot = MagicMock()
-        mock_snapshot.resources = [{"resource_type": "s3:bucket", "name": "test", "config": {}}]
+        mock_snapshot.resources = [{"resource_type": "s3:bucket", "name": "test", "config": {"BucketName": "test"}}]
         mock_storage = MagicMock()
         mock_storage.load_snapshot.return_value = mock_snapshot
         mock_storage_class.return_value = mock_storage
@@ -228,7 +232,8 @@ guardrails: []
 resources:
   - resource_type: s3:bucket
     name: test-bucket
-    config: {}
+    config:
+      BucketName: test-bucket
 """
         )
 
@@ -415,3 +420,68 @@ class TestGuardrailsCommandHelp:
         assert "--severity" in result.stdout
         assert "--category" in result.stdout
         assert "--format" in result.stdout
+
+
+class TestWarnMissingConfig:
+    """Tests for _warn_missing_config validation helper."""
+
+    def _make_resource(self, config: object = None, raw_config: object = None) -> MagicMock:
+        r = MagicMock()
+        r.config = config
+        r.raw_config = raw_config
+        return r
+
+    def test_empty_list_returns_zero(self) -> None:
+        assert _warn_missing_config([], Console()) == 0
+
+    def test_all_have_config_returns_zero(self) -> None:
+        resources = [self._make_resource(config={"BucketName": "x"})]
+        assert _warn_missing_config(resources, Console()) == 0
+
+    def test_all_have_raw_config_returns_zero(self) -> None:
+        resources = [self._make_resource(raw_config={"BucketName": "x"})]
+        assert _warn_missing_config(resources, Console()) == 0
+
+    def test_all_missing_config_exits_1(self) -> None:
+        resources = [
+            self._make_resource(config=None, raw_config=None),
+            self._make_resource(config={}, raw_config={}),
+        ]
+        with pytest.raises(click.exceptions.Exit):
+            _warn_missing_config(resources, Console())
+
+    def test_some_missing_config_returns_count(self) -> None:
+        resources = [
+            self._make_resource(config={"BucketName": "x"}),
+            self._make_resource(config=None, raw_config=None),
+        ]
+        assert _warn_missing_config(resources, Console()) == 1
+
+    def test_all_missing_error_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        resources = [self._make_resource(config=None, raw_config=None)]
+        con = Console()
+        with pytest.raises(click.exceptions.Exit):
+            _warn_missing_config(resources, con)
+
+    @patch("src.cli.guardrails.load_builtin_guardrails")
+    @patch("src.cli.guardrails.GuardrailEvaluator")
+    def test_check_from_file_all_missing_config_exits_1(
+        self,
+        mock_evaluator_class: MagicMock,
+        mock_load_builtin: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Check command exits 1 when all resources lack config data."""
+        inventory_file = tmp_path / "inventory.yaml"
+        inventory_file.write_text(
+            """
+resources:
+  - resource_type: s3:bucket
+    name: test-bucket
+"""
+        )
+        mock_load_builtin.return_value = []
+
+        result = runner.invoke(app, ["guardrails", "check", "--from-file", str(inventory_file)])
+        assert result.exit_code == 1
+        assert "no configuration data" in result.stdout


### PR DESCRIPTION
## Summary
- Adds `_warn_missing_config()` helper to detect resources without `config`/`raw_config` data before evaluation
- When **all** resources lack config: prints actionable error and exits 1 (no point evaluating)
- When **some** resources lack config: prints warning with count, continues evaluation
- Called in both `guardrails check` command and `main.py` dry-run guardrails path

Closes #87

## Test plan
- [x] `pytest tests/unit/guardrails/ --no-cov` — all 128 existing tests pass
- [x] `pytest tests/unit/cli/ --no-cov` — all 22 tests pass (including 7 new tests)
- [ ] Manual: `awsinv guardrails check <snapshot>` with good data — no warning
- [ ] Manual: create YAML file with resources missing config keys — should error

🤖 Generated with [Claude Code](https://claude.com/claude-code)