### PR TITLE
Fix: include builtin guardrails YAML in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,9 @@ recursive-include src *.py
 # Include CDK template files
 recursive-include src/generate/templates *.template
 
+# Include built-in guardrails definitions
+recursive-include src/guardrails/builtin *.yaml
+
 # Include web templates and static files
 recursive-include src/web/templates *.html
 recursive-include src/web/static *.css *.js

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws-inventory-manager"
-version = "1.3.2"
+version = "1.3.3"
 description = "AWS Resource Inventory Management & Delta Tracking CLI tool"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -75,6 +75,7 @@ include = ["src*"]
 "src.web" = ["templates/**/*.html", "static/**/*.css", "static/**/*.js"]
 "src.copilot" = ["templates/**/*.md"]
 "src.generate" = ["templates/**/*.template"]
+"src.guardrails.builtin" = ["*.yaml"]
 
 [tool.ruff]
 line-length = 120

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """AWS Baseline Snapshot & Delta Tracking tool."""
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"


### PR DESCRIPTION
## Summary
- Builtin guardrails YAML files (`encryption.yaml`, `logging.yaml`, `network.yaml`, `tagging.yaml`) were missing from the distributed wheel
- This caused `awsinv guardrails check` to load 0 guardrails and report 0 evaluations (false "all passed")
- Added `src.guardrails.builtin` to `[tool.setuptools.package-data]` in `pyproject.toml`
- Added `recursive-include src/guardrails/builtin *.yaml` to `MANIFEST.in`
- Bumps version to 1.3.3

Closes #89

## Test plan
- [x] Verified YAML files present in built wheel (`zipfile -l`)
- [x] Installed wheel locally, confirmed files in site-packages
- [x] `awsinv guardrails check calvinware-test` now returns 978 evaluations (was 0)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)