### PR TITLE
docs: introduce collection concept before snapshots (#101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Inventory Snapshots** | **Configuration Drift** | **Security Scanning** | **Cost Analysis** | **Resource Cleanup** | **IaC Generation**
+**Collections** | **Inventory Snapshots** | **Configuration Drift** | **Security Scanning** | **Cost Analysis** | **Resource Cleanup** | **IaC Generation**
 
 [Documentation](https://troylar.github.io/aws-inventory-manager/) | [Quick Start](#quick-start) | [Features](#features) | [Contributing](#contributing)
 
@@ -46,19 +46,22 @@ pip install aws-inventory-manager
 Or with pipx: `pipx install aws-inventory-manager`
 
 ```bash
-# 1. Capture current state
-awsinv snapshot create my-baseline --region us-east-1
+# 1. Organize snapshots into a collection
+awsinv collection create prod-baseline --description "Production account"
 
-# 2. View what was captured
+# 2. Capture current state into the collection
+awsinv snapshot create my-baseline --collection prod-baseline --region us-east-1
+
+# 3. View what was captured
 awsinv snapshot report
 
-# 3. Track changes
+# 4. Track changes
 awsinv delta --snapshot my-baseline --show-diff
 
-# 4. Find security issues
+# 5. Find security issues
 awsinv security scan --severity HIGH
 
-# 5. Clean up (always preview first!)
+# 6. Clean up (always preview first!)
 awsinv cleanup preview my-baseline
 awsinv cleanup execute my-baseline --yes
 ```
@@ -69,6 +72,7 @@ awsinv cleanup execute my-baseline --yes
 
 ## Features
 
+- **Collections** -- Named containers for organizing snapshots by account, environment, or team ([guide](https://troylar.github.io/aws-inventory-manager/guides/collections/))
 - **Inventory Snapshots** -- 27 AWS services, 80+ resource types, multi-region, Lambda code collection, SQLite storage ([guide](https://troylar.github.io/aws-inventory-manager/guides/snapshots/))
 - **Change Tracking** -- Field-level drift detection with before/after diff ([guide](https://troylar.github.io/aws-inventory-manager/guides/change-tracking/))
 - **Security Scanning** -- 12+ CIS-aligned checks across severity levels ([guide](https://troylar.github.io/aws-inventory-manager/guides/security-scanning/))
@@ -92,7 +96,7 @@ Full documentation is available at **[troylar.github.io/aws-inventory-manager](h
 |---------|-------------|
 | [Getting Started](https://troylar.github.io/aws-inventory-manager/getting-started/installation/) | Installation, first snapshot, common workflows |
 | [Configuration](https://troylar.github.io/aws-inventory-manager/configuration/environment-variables/) | Environment variables, AWS Config, data storage, multi-account |
-| [Guides](https://troylar.github.io/aws-inventory-manager/guides/snapshots/) | How-to guides for every feature |
+| [Guides](https://troylar.github.io/aws-inventory-manager/guides/collections/) | How-to guides for every feature |
 | [Guardrails](https://troylar.github.io/aws-inventory-manager/guardrails/) | Policy-based compliance checking |
 | [Reference](https://troylar.github.io/aws-inventory-manager/reference/cli/) | CLI reference, IAM permissions, supported resources, database schema |
 | [Development](https://troylar.github.io/aws-inventory-manager/development/contributing/) | Contributing, testing, architecture |
@@ -126,6 +130,7 @@ awsinv cleanup purge --protect-tag "baseline=true" --yes
 
 | Command Group | Description |
 |--------------|-------------|
+| `awsinv collection` | Create, list, show, delete snapshot collections |
 | `awsinv snapshot` | Create, list, export, enrich snapshots |
 | `awsinv delta` | Track changes since a baseline |
 | `awsinv security` | Run CIS-aligned security scans |

--- a/docs/getting-started/first-snapshot.md
+++ b/docs/getting-started/first-snapshot.md
@@ -6,19 +6,27 @@ This tutorial walks you through creating your first inventory snapshot, viewing 
 
 | Term | Meaning |
 |------|---------|
+| **Collection** | A named container for organizing snapshots by environment, team, or purpose. Create a collection first, then add snapshots to it. |
 | **Snapshot** | A point-in-time inventory of your AWS resources (stored in local SQLite database). Not an EBS/RDS snapshot. |
-| **Collection** | A named group of snapshots. Use collections to organize snapshots by environment, team, or purpose. |
 | **Cleanup** | Delete resources that were created *after* a snapshot, returning to that baseline state. |
 | **Purge** | Delete all resources *except* those matching protection rules. Filter by creator or date range. |
 | **Query** | Search and analyze resources across snapshots using SQL or built-in filters. |
 | **IaC Generation** | Generate Terraform or CDK code from a snapshot's resources. Requires `pip install aws-inventory-manager[generate]`. |
 
-## Step 1: Create a Snapshot
+## Step 1: Create a Collection
 
-Capture the current state of your AWS resources:
+Collections organize your snapshots by environment, team, or purpose. Start by creating one:
 
 ```bash
-awsinv snapshot create my-baseline --region us-east-1
+awsinv collection create my-project --description "My first collection"
+```
+
+## Step 2: Create a Snapshot
+
+Capture the current state of your AWS resources into the collection:
+
+```bash
+awsinv snapshot create my-baseline --collection my-project --region us-east-1
 ```
 
 This takes 30--60 seconds depending on resource count. The tool scans 27 AWS services and catalogs 80+ resource types.
@@ -26,7 +34,7 @@ This takes 30--60 seconds depending on resource count. The tool scans 27 AWS ser
 !!! tip
     If you have [AWS Config](../configuration/aws-config-integration.md) enabled, collection can be up to 5x faster. The tool detects it automatically.
 
-## Step 2: View What Was Captured
+## Step 3: View What Was Captured
 
 ```bash
 awsinv snapshot report
@@ -54,7 +62,7 @@ For a detailed view of all resources:
 awsinv snapshot report --detailed
 ```
 
-## Step 3: Track Changes
+## Step 4: Track Changes
 
 After making changes to your AWS environment, compare against your baseline:
 
@@ -68,7 +76,7 @@ This shows:
 - Resources that were deleted
 - Configuration changes (field-level diff)
 
-## Step 4: Export Your Snapshot
+## Step 5: Export Your Snapshot
 
 Export data for external analysis:
 
@@ -83,7 +91,7 @@ awsinv snapshot export my-baseline -o inventory.csv
 awsinv snapshot export my-baseline -o inventory.yaml
 ```
 
-## Step 5: Generate IaC from Your Snapshot
+## Step 6: Generate IaC from Your Snapshot
 
 Turn your captured inventory into infrastructure as code:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,16 @@ in your account.
 === "Collection"
 
     ```bash
-    awsinv snapshot create my-baseline --region us-east-1,us-west-2
+    awsinv collection create prod-baseline --description "Production account"
+    awsinv collection create staging --description "Staging environment"
+    awsinv collection list
+    awsinv collection show prod-baseline
+    ```
+
+=== "Snapshot"
+
+    ```bash
+    awsinv snapshot create my-baseline --collection prod-baseline --region us-east-1,us-west-2
     awsinv snapshot report --detailed
     awsinv snapshot export my-baseline -o inventory.yaml --type s3 --tag env=prod
     ```
@@ -64,6 +73,14 @@ in your account.
 ## Features
 
 <div class="grid cards" markdown>
+
+-   :material-folder-multiple:{ .lg .middle } **Collections**
+
+    ---
+
+    Named containers for organizing snapshots by account, environment, or team. Each collection tracks an active baseline snapshot and supports tag-based filtering.
+
+    [:octicons-arrow-right-24: Collections guide](guides/collections.md)
 
 -   :material-camera:{ .lg .middle } **Inventory Snapshots**
 
@@ -203,7 +220,8 @@ in your account.
 
 ```bash
 pip install aws-inventory-manager
-awsinv snapshot create my-baseline --region us-east-1
+awsinv collection create my-project --description "My AWS project"
+awsinv snapshot create my-baseline --collection my-project --region us-east-1
 awsinv snapshot report --detailed
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,8 +89,8 @@ nav:
     - Data Storage: configuration/data-storage.md
     - Multi-Account Support: configuration/multi-account.md
   - Guides:
-    - Snapshots: guides/snapshots.md
     - Collections: guides/collections.md
+    - Snapshots: guides/snapshots.md
     - IaC Generation: guides/iac-generation.md
     - Change Tracking: guides/change-tracking.md
     - Security Scanning: guides/security-scanning.md


### PR DESCRIPTION
## Summary
- Reorder nav: Collections before Snapshots in Guides sidebar
- Add Collections to README feature bar, feature list, command reference, and Quick Start
- Fix docs/index.md "Collection" tab to show actual collection commands; add separate "Snapshot" tab
- Add Collections feature card to docs homepage
- Update first-snapshot tutorial: collection creation is now Step 1, all steps renumbered
- Reorder Key Concepts table: Collection before Snapshot

Closes #101

## Test plan
- [ ] Verify mkdocs builds without errors
- [ ] Check sidebar nav order: Collections appears before Snapshots
- [ ] Verify README Quick Start shows collection create before snapshot create
- [ ] Verify first-snapshot tutorial steps are correctly numbered 1-6
- [ ] Check docs homepage tabs: "Collection" and "Snapshot" are separate with correct commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)