### PR TITLE
chore: bump version to 2.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws-inventory-manager"
-version = "2.1.0"
+version = "2.1.1"
 description = "Know Everything About Your AWS Environment"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump version to 2.1.1 for PyPI release

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)