### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.0] - 2026-02-09
 
 ### Added
 - **Debug Flag for enrich-creators**: `--debug` flag for `snapshot enrich-creators` that shows verbose matching diagnostics (resource key building, event type filtering, CloudTrail results, per-type match rates)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws-inventory-manager"
-version = "2.1.1"
+version = "2.2.0"
 description = "Know Everything About Your AWS Environment"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump version from 2.1.1 to 2.2.0 for the enrich-creators `--debug` flag feature
- Update changelog [Unreleased] to [2.2.0] - 2026-02-09

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)