### PR TITLE
fix(cloudtrail): fix enrich-creators matching for 5 resource types

### DIFF
--- a/src/cloudtrail/query.py
+++ b/src/cloudtrail/query.py
@@ -124,6 +124,9 @@ RESOURCE_TYPE_NORMALIZATION: Dict[str, str] = {
     "AWS::WAFv2::WebACL::CloudFront": "AWS::WAFv2::WebACL",
     "AWS::ApiGatewayV2::Api::HTTP": "AWS::ApiGatewayV2::Api",
     "AWS::ApiGatewayV2::Api::WebSocket": "AWS::ApiGatewayV2::Api",
+    # Short-form resource types used by some collectors
+    "efs:file-system": "AWS::EFS::FileSystem",
+    "elasticache:cluster": "AWS::ElastiCache::CacheCluster",
 }
 
 
@@ -385,6 +388,9 @@ class CloudTrailQuery:
             "ruleName",
             "secretId",
             "parameterName",
+            "logGroupName",
+            "alarmName",
+            "nodegroupName",
             "databaseName",
             "crawlerName",
             "jobName",


### PR DESCRIPTION
## Summary
- Add type normalization for `efs:file-system` and `elasticache:cluster` (short-form -> AWS:: format)
- Add `logGroupName`, `alarmName`, `nodegroupName` to CloudTrail event name extraction

Fixes #115

## Test plan
- [x] 77 cloudtrail unit tests pass
- [ ] Run `awsinv snapshot enrich-creators --debug` and confirm no more "Could not extract resource name from CreateLogGroup" spam
- [ ] Verify EFS and ElastiCache resources now match

🤖 Generated with [Claude Code](https://claude.com/claude-code)