### PR TITLE
chore: bump version to 2.4.0 (#124)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws-inventory-manager"
-version = "2.3.0"
+version = "2.4.0"
 description = "Know Everything About Your AWS Environment"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump version from 2.3.0 to 2.4.0 for release with unified guardrails generate command

Closes #124