### PR TITLE
chore: bump version to 2.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws-inventory-manager"
-version = "2.4.0"
+version = "2.5.0"
 description = "Know Everything About Your AWS Environment"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump version to 2.5.0 for infrastructure patterns release

## Changes
- `pyproject.toml`: version 2.4.0 -> 2.5.0

Addresses #127