### PR TITLE
docs: add patterns as top-level nav section

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,8 @@ nav:
     - Policy Reference: guardrails/policy-reference.md
     - Formula Syntax: guardrails/formula-syntax.md
     - CI/CD Integration: guardrails/ci-cd-integration.md
+  - Patterns:
+    - Overview: patterns/index.md
   - Reference:
     - CLI Reference: reference/cli.md
     - Supported Resources: reference/supported-resources.md


### PR DESCRIPTION
## Summary
- Add "Patterns" as its own top-level navigation section in mkdocs, at the same level as Guardrails
- Gives patterns the same prominence as guardrails in the docs site nav tabs

Addresses #127