### PR TITLE
docs: add Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs configuration
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs


### PR DESCRIPTION
## Summary
- Add `.readthedocs.yaml` configuration for Read the Docs integration
- Uses Python 3.13, Ubuntu 24.04, installs `[docs]` extras from pyproject.toml
- Points to existing `mkdocs.yml` configuration

## Setup required
After merging, connect the repo at https://readthedocs.org/dashboard/import/manual/:
1. Repository URL: `https://github.com/troylar/aws-inventory-manager`
2. Default branch: `main`
3. RTD will auto-build on every push to main

Addresses #127