### PR TITLE
feat(llm): add OpenAI SDK as alternative LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ awsinv cleanup execute my-baseline --yes
 - **AWS Config Integration** -- Auto-detected, up to 5x faster collection ([guide](https://aws-inventory-manager.readthedocs.io/configuration/aws-config-integration/))
 - **Query & Analysis** -- SQL queries, resource search, cross-snapshot history ([guide](https://aws-inventory-manager.readthedocs.io/guides/query-analysis/))
 - **Creator Tracking** -- CloudTrail-based resource provenance ([guide](https://aws-inventory-manager.readthedocs.io/guides/creator-tracking/))
-- **IaC Generation** -- Terraform, CDK TypeScript, CDK Python via AI ([guide](https://aws-inventory-manager.readthedocs.io/guides/iac-generation/))
+- **IaC Generation** -- Terraform, CDK TypeScript, CDK Python via AI (Bedrock or OpenAI) ([guide](https://aws-inventory-manager.readthedocs.io/guides/iac-generation/))
 - **Guardrails** -- Policy-based compliance checking, AI auto-fix, CI/CD ready ([guide](https://aws-inventory-manager.readthedocs.io/guardrails/))
 - **Infrastructure Patterns** -- Reusable architecture blueprints, snapshot comparison, compliance reporting ([guide](https://aws-inventory-manager.readthedocs.io/patterns/))
 - **Web UI** -- Resource Explorer with advanced filtering and export ([guide](https://aws-inventory-manager.readthedocs.io/guides/web-ui/))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2026-02-11
+
+### Added
+- **OpenAI LLM Provider**: Use OpenAI (or any OpenAI-compatible API) as an alternative to AWS Bedrock for all AI features
+  - New `--provider` flag on `generate` and `compare` commands (`bedrock` or `openai`)
+  - `--openai-model`, `--openai-api-key`, `--openai-base-url` CLI flags
+  - Environment variables: `AWSINV_LLM_PROVIDER`, `AWSINV_OPENAI_API_KEY`, `AWSINV_OPENAI_MODEL`, `AWSINV_OPENAI_BASE_URL`
+  - Works with IaC generation, guardrails (evaluation, auto-fix, generation), and pattern generation/guidance
+  - Optional dependency: `pip install aws-inventory-manager[openai]`
+  - Provider-specific default models per task type (generation, evaluation, auto-fix)
+  - Compatible with Azure OpenAI and other OpenAI-compatible endpoints via `--openai-base-url`
+
+### Changed
+- **Unified LLM Abstraction**: All AI features now use a shared `LLMClient` instead of direct boto3 Bedrock calls
+  - Bedrock backend uses the Converse API for both streaming and non-streaming calls
+  - Consistent error handling across providers
+
 ## [2.2.0] - 2026-02-09
 
 ### Added

--- a/docs/cli-conventions.md
+++ b/docs/cli-conventions.md
@@ -22,6 +22,10 @@ Every command that uses one of these concepts MUST use the canonical name and sh
 | Collection | `--collection` | `-i` | str | Single value | `AWSINV_COLLECTION_ID` |
 | Description | `--description` | `-d` | str | Single value | -- |
 | Storage path | `--storage-path` | -- | str | Single value | `AWSINV_STORAGE_PATH` |
+| LLM provider | `--provider` | -- | str | Choice: bedrock, openai | `AWSINV_LLM_PROVIDER` |
+| OpenAI model | `--openai-model` | -- | str | Single value | `AWSINV_OPENAI_MODEL` |
+| OpenAI API key | `--openai-api-key` | -- | str | Single value | `AWSINV_OPENAI_API_KEY` |
+| OpenAI base URL | `--openai-base-url` | -- | str | Single value | `AWSINV_OPENAI_BASE_URL` |
 
 ## Short Flag Assignments
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -4,6 +4,8 @@ Configure most CLI options via environment variables. Useful for CI/CD pipelines
 
 ## Available Variables
 
+### General
+
 | Variable | Description | Equivalent Flag |
 |----------|-------------|-----------------|
 | `AWSINV_SNAPSHOT_ID` | Default snapshot name for queries | `--snapshot` |
@@ -11,8 +13,17 @@ Configure most CLI options via environment variables. Useful for CI/CD pipelines
 | `AWSINV_REGION` | Default region (repeatable via CLI: `-r us-east-1 -r us-west-2`) | `--region` |
 | `AWSINV_PROFILE` | AWS CLI profile to use | `--profile` |
 | `AWSINV_STORAGE_PATH` | Custom path for SQLite DB and logs | `--storage-path` |
+
+### LLM Provider
+
+| Variable | Description | Equivalent Flag |
+|----------|-------------|-----------------|
+| `AWSINV_LLM_PROVIDER` | LLM provider: `bedrock` (default) or `openai` | `--provider` |
 | `AWSINV_BEDROCK_MODEL_ID` | Bedrock model ID for IaC generation | `--model-id` |
 | `AWSINV_BEDROCK_REGION` | AWS region for Bedrock API | `--region` |
+| `AWSINV_OPENAI_API_KEY` | OpenAI API key (required when provider is `openai`) | `--openai-api-key` |
+| `AWSINV_OPENAI_MODEL` | OpenAI model name (default: `gpt-4o`) | `--openai-model` |
+| `AWSINV_OPENAI_BASE_URL` | Custom OpenAI-compatible API base URL | `--openai-base-url` |
 
 ## Usage Example
 
@@ -35,4 +46,25 @@ env:
 steps:
   - run: awsinv snapshot create ci-baseline
   - run: awsinv security scan --output report.json
+```
+
+## OpenAI Provider Example
+
+```bash
+export AWSINV_LLM_PROVIDER="openai"
+export AWSINV_OPENAI_API_KEY="sk-..."
+
+# These commands will now use OpenAI instead of Bedrock
+awsinv generate terraform my-snapshot
+awsinv guardrails generate "S3 buckets must have encryption"
+awsinv patterns generate "serverless REST API"
+```
+
+You can also use an OpenAI-compatible API (e.g., Azure OpenAI, local models):
+
+```bash
+export AWSINV_LLM_PROVIDER="openai"
+export AWSINV_OPENAI_API_KEY="your-key"
+export AWSINV_OPENAI_BASE_URL="https://your-endpoint.openai.azure.com/v1"
+export AWSINV_OPENAI_MODEL="gpt-4o"
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -38,8 +38,14 @@ pip install aws-inventory-manager[web]
 # IaC Generation (Terraform/CDK)
 pip install aws-inventory-manager[generate]
 
+# OpenAI LLM provider (alternative to AWS Bedrock)
+pip install aws-inventory-manager[openai]
+
+# Multiple extras
+pip install aws-inventory-manager[generate,openai]
+
 # All extras
-pip install aws-inventory-manager[web,generate]
+pip install aws-inventory-manager[web,generate,openai]
 ```
 
 ## Development Installation

--- a/docs/guardrails/index.md
+++ b/docs/guardrails/index.md
@@ -116,7 +116,7 @@ awsinv guardrails list --category ENC
 # Validate a policy file
 awsinv guardrails validate ./policy.yaml --verbose
 
-# Generate guardrails from natural language (requires Bedrock)
+# Generate guardrails from natural language (requires Bedrock or OpenAI)
 awsinv guardrails generate "S3 buckets must have encryption"
 awsinv guardrails generate "production security baseline" --count 10
 awsinv guardrails generate --from-file rules.csv --instructions "format is ID: description"

--- a/docs/guides/iac-generation.md
+++ b/docs/guides/iac-generation.md
@@ -1,6 +1,6 @@
 # IaC Generation
 
-Generate Infrastructure as Code from your inventory snapshots using AWS Bedrock. Supports Terraform, CDK TypeScript, and CDK Python.
+Generate Infrastructure as Code from your inventory snapshots using AI. Supports Terraform, CDK TypeScript, and CDK Python. Choose between AWS Bedrock (default) or OpenAI as your LLM provider.
 
 ## Quick Start
 
@@ -32,10 +32,21 @@ awsinv generate terraform --from-file export.yaml --output ./infra
 # Specify output directory and project name
 awsinv generate cdk-typescript my-snapshot --output ./my-cdk-app
 
-# Use different model or region
+# Use different Bedrock model or region
 awsinv generate terraform my-snapshot \
   --model-id anthropic.claude-opus-4-20250514-v1:0 \
   --region us-west-2
+
+# Use OpenAI instead of Bedrock
+awsinv generate terraform my-snapshot --provider openai --openai-api-key sk-...
+
+# Use a specific OpenAI model
+awsinv generate terraform my-snapshot \
+  --provider openai --openai-model gpt-4o --openai-api-key sk-...
+
+# Use an OpenAI-compatible endpoint (e.g., Azure OpenAI)
+awsinv generate terraform my-snapshot \
+  --provider openai --openai-base-url https://your-endpoint/v1 --openai-api-key your-key
 
 # Dry run (show what would be generated)
 awsinv generate terraform my-snapshot --dry-run
@@ -183,10 +194,24 @@ Resources are generated in dependency sequence:
 
 ## Requirements
 
-- AWS credentials with Bedrock access (uses your configured AWS profile)
-- Default model: `anthropic.claude-opus-4-20250514-v1:0` (Claude Opus 4)
+=== "Bedrock (default)"
+
+    - AWS credentials with Bedrock access (uses your configured AWS profile)
+    - Default model: `anthropic.claude-opus-4-20250514-v1:0` (Claude Opus 4)
+
+=== "OpenAI"
+
+    - OpenAI API key (set via `--openai-api-key` or `AWSINV_OPENAI_API_KEY`)
+    - Default model: `gpt-4o`
+    - Install the optional dependency: `pip install aws-inventory-manager[openai]`
+
+**Common requirements:**
+
 - For CDK TypeScript: Node.js 18+ and npm (for validation)
 - For CDK Python: Python 3.8+ (for validation)
 
 !!! note
     IaC generation requires the `langgraph` optional dependency: `pip install aws-inventory-manager[generate]`
+
+!!! tip
+    All LLM provider settings can be configured via environment variables. See [Environment Variables](../configuration/environment-variables.md#llm-provider) for details.

--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -312,7 +312,7 @@ expect:
 
 ## AI Pattern Generation
 
-Generate patterns using AWS Bedrock (requires Bedrock access).
+Generate patterns using AI (requires AWS Bedrock or OpenAI access).
 
 ### From a Description
 
@@ -443,10 +443,10 @@ awsinv patterns compare --snapshot my-snapshot --threshold 0.75
 
 ### AI Guidance
 
-By default, the comparison engine generates AI-powered guidance using Bedrock for the top match. This adds remediation suggestions based on the gaps found. Disable it if you don't have Bedrock access or want faster results:
+By default, the comparison engine generates AI-powered guidance for the top match using your configured LLM provider (Bedrock or OpenAI). This adds remediation suggestions based on the gaps found. Disable it if you don't have LLM access or want faster results:
 
 ```bash
-# Skip AI guidance (deterministic only, no Bedrock needed)
+# Skip AI guidance (deterministic only, no LLM needed)
 awsinv patterns compare --snapshot my-snapshot --no-guidance
 ```
 
@@ -726,7 +726,7 @@ Each pattern is saved as `{name}-v{version}.yaml` in the library directory:
 | Command | Description |
 |---------|-------------|
 | `patterns add <file>` | Add a pattern YAML file to the library |
-| `patterns generate <description>` | Generate a pattern using AI (Bedrock) |
+| `patterns generate <description>` | Generate a pattern using AI (Bedrock or OpenAI) |
 | `patterns list` | List all patterns (with filtering options) |
 | `patterns show <name>` | Show detailed pattern information |
 | `patterns compare --snapshot <name>` | Compare a snapshot against the pattern library |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws-inventory-manager"
-version = "2.5.0"
+version = "2.6.0"
 description = "Know Everything About Your AWS Environment"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -54,6 +54,9 @@ web = [
 ]
 generate = [
     "langgraph>=0.2.0",
+]
+openai = [
+    "openai>=1.0.0",
 ]
 docs = [
     "mkdocs>=1.6.0",

--- a/src/cli/guardrails.py
+++ b/src/cli/guardrails.py
@@ -536,15 +536,17 @@ def list_guardrails(
     raise typer.Exit(0)
 
 
-def _get_bedrock_client():
-    """Get Bedrock client for AI operations."""
+def _get_llm_client():
+    """Get LLM client for AI operations."""
     try:
-        import boto3
+        from ..llm import LLMClient, LLMConfig
 
-        return boto3.client("bedrock-runtime")
+        return LLMClient(LLMConfig.from_env())
     except Exception as e:
-        console.print(f"[red]Error:[/red] Failed to create Bedrock client: {e}")
-        console.print("Make sure you have AWS credentials configured.")
+        console.print(f"[red]Error:[/red] Failed to create LLM client: {e}")
+        console.print(
+            "Check your provider configuration (AWS credentials for Bedrock, or AWSINV_OPENAI_API_KEY for OpenAI)."
+        )
         return None
 
 
@@ -805,8 +807,8 @@ def generate_guardrails(
         console.print("[red]Error:[/red] --format and --instructions are only valid with --from-file")
         raise typer.Exit(1)
 
-    bedrock = _get_bedrock_client()
-    if not bedrock:
+    llm = _get_llm_client()
+    if not llm:
         raise typer.Exit(1)
 
     guardrails_result = []
@@ -831,7 +833,7 @@ def generate_guardrails(
         guardrails_result = translate_rules_to_guardrails(
             rules=rules,
             instructions=instructions,
-            bedrock_client=bedrock,
+            llm_client=llm,
         )
 
         if len(guardrails_result) < len(rules):
@@ -845,7 +847,7 @@ def generate_guardrails(
         console.print(f"[dim]Generating guardrail for: {description}[/dim]")
         console.print()
 
-        guardrail = generate_guardrail(description, bedrock_client=bedrock)
+        guardrail = generate_guardrail(description, llm_client=llm)
         if guardrail:
             guardrails_result = [guardrail]
 
@@ -864,7 +866,7 @@ def generate_guardrails(
             description=description,
             count=count,
             resource_types=resource_types,
-            bedrock_client=bedrock,
+            llm_client=llm,
         )
 
     if not guardrails_result:

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -6776,6 +6776,26 @@ def generate(
         help="AWS region for Bedrock (default: from AWSINV_BEDROCK_REGION)",
         envvar=["AWSINV_REGION", "AWS_REGION"],
     ),
+    provider: Optional[str] = typer.Option(
+        None,
+        "--provider",
+        help="LLM provider: bedrock or openai (default: from AWSINV_LLM_PROVIDER or bedrock)",
+    ),
+    openai_model: Optional[str] = typer.Option(
+        None,
+        "--openai-model",
+        help="OpenAI model name (default: gpt-4o)",
+    ),
+    openai_api_key: Optional[str] = typer.Option(
+        None,
+        "--openai-api-key",
+        help="OpenAI API key (default: from AWSINV_OPENAI_API_KEY)",
+    ),
+    openai_base_url: Optional[str] = typer.Option(
+        None,
+        "--openai-base-url",
+        help="OpenAI-compatible base URL (default: from AWSINV_OPENAI_BASE_URL)",
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed progress"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show what would be generated without creating files"),
     no_best_practices: bool = typer.Option(
@@ -6802,7 +6822,7 @@ def generate(
     guardrails_auto_fix: bool = typer.Option(
         True,
         "--guardrails-auto-fix/--no-guardrails-auto-fix",
-        help="Enable AI auto-fix for AUTO-FIX guardrails (requires Bedrock access)",
+        help="Enable AI auto-fix for AUTO-FIX guardrails",
     ),
     guardrails_report: Optional[str] = typer.Option(
         None,
@@ -6812,7 +6832,7 @@ def generate(
 ) -> None:
     """Generate IaC (Terraform/CDK) from an inventory snapshot or export file.
 
-    Uses AWS Bedrock for AI-powered code generation.
+    Uses AI (AWS Bedrock or OpenAI) for code generation.
 
     Formats:
         terraform      - HashiCorp Terraform (.tf files)
@@ -6838,6 +6858,18 @@ def generate(
     if format not in ["terraform", "cdk-typescript", "cdk-python"]:
         console.print(f"[red]Error:[/red] Unknown format '{format}'. Use: terraform, cdk-typescript, cdk-python")
         raise typer.Exit(1)
+
+    # Set LLM provider env vars from CLI flags
+    import os
+
+    if provider:
+        os.environ["AWSINV_LLM_PROVIDER"] = provider
+    if openai_model:
+        os.environ["AWSINV_OPENAI_MODEL"] = openai_model
+    if openai_api_key:
+        os.environ["AWSINV_OPENAI_API_KEY"] = openai_api_key
+    if openai_base_url:
+        os.environ["AWSINV_OPENAI_BASE_URL"] = openai_base_url
 
     # Validate input - need either snapshot_name or from_file
     if not snapshot_name and not from_file:
@@ -7265,6 +7297,26 @@ def compare(
         help="AWS region for Bedrock (default: from AWSINV_BEDROCK_REGION)",
         envvar=["AWSINV_REGION", "AWS_REGION"],
     ),
+    provider: Optional[str] = typer.Option(
+        None,
+        "--provider",
+        help="LLM provider: bedrock or openai (default: from AWSINV_LLM_PROVIDER or bedrock)",
+    ),
+    openai_model: Optional[str] = typer.Option(
+        None,
+        "--openai-model",
+        help="OpenAI model name (default: gpt-4o)",
+    ),
+    openai_api_key: Optional[str] = typer.Option(
+        None,
+        "--openai-api-key",
+        help="OpenAI API key (default: from AWSINV_OPENAI_API_KEY)",
+    ),
+    openai_base_url: Optional[str] = typer.Option(
+        None,
+        "--openai-base-url",
+        help="OpenAI-compatible base URL (default: from AWSINV_OPENAI_BASE_URL)",
+    ),
     output_json: bool = typer.Option(False, "--json", help="Output results as JSON"),
 ) -> None:
     """Compare inventory coverage against existing IaC code.
@@ -7295,13 +7347,21 @@ def compare(
         console.print(f"Details: {e}")
         raise typer.Exit(1)
 
-    # Set environment variables for model/region if provided
+    # Set environment variables for model/region/provider if provided
     import os
 
     if model_id:
         os.environ["AWSINV_BEDROCK_MODEL_ID"] = model_id
     if region:
         os.environ["AWSINV_BEDROCK_REGION"] = region
+    if provider:
+        os.environ["AWSINV_LLM_PROVIDER"] = provider
+    if openai_model:
+        os.environ["AWSINV_OPENAI_MODEL"] = openai_model
+    if openai_api_key:
+        os.environ["AWSINV_OPENAI_API_KEY"] = openai_api_key
+    if openai_base_url:
+        os.environ["AWSINV_OPENAI_BASE_URL"] = openai_base_url
 
     source_name = from_file if from_file else snapshot_name or ""
 

--- a/src/cli/patterns.py
+++ b/src/cli/patterns.py
@@ -92,11 +92,11 @@ def generate_pattern(
         raise typer.Exit(code=1)
 
     try:
-        import boto3
+        from ..llm import LLMClient, LLMConfig
 
-        bedrock_client = boto3.client("bedrock-runtime")
-    except Exception:
-        console.print("[red]Error:[/red] Bedrock credentials required for pattern generation.")
+        llm_client = LLMClient(LLMConfig.from_env())
+    except Exception as e:
+        console.print(f"[red]Error:[/red] LLM credentials required for pattern generation: {e}")
         raise typer.Exit(code=1)
 
     guardrail_names = None
@@ -111,13 +111,13 @@ def generate_pattern(
                 snapshot_name=from_snapshot,
                 instructions=instructions,
                 guardrail_names=guardrail_names,
-                bedrock_client=bedrock_client,
+                llm_client=llm_client,
             )
         else:
             pattern = generate_from_description(
                 description=description,  # type: ignore[arg-type]
                 instructions=instructions,
-                bedrock_client=bedrock_client,
+                llm_client=llm_client,
             )
     except Exception as exc:
         console.print(f"[red]Error:[/red] {exc}")
@@ -221,13 +221,12 @@ def compare_patterns(
 
     if not no_guidance and report.matches:
         try:
-            import boto3
-
-            bedrock_client = boto3.client("bedrock-runtime")
+            from ..llm import LLMClient, LLMConfig
             from ..patterns.generator import generate_guidance
 
+            llm_client = LLMClient(LLMConfig.from_env())
             for match in report.matches:
-                guidance = generate_guidance(report, bedrock_client=bedrock_client)
+                guidance = generate_guidance(report, llm_client=llm_client)
                 if guidance:
                     match.guidance = guidance
                     break

--- a/src/generate/cdk_generator.py
+++ b/src/generate/cdk_generator.py
@@ -104,6 +104,10 @@ class CDKGenerator:
             bedrock_region=region or base_config.bedrock_region,
             max_retries=base_config.max_retries,
             output_format=output_format,
+            provider=base_config.provider,
+            openai_model=base_config.openai_model,
+            openai_api_key=base_config.openai_api_key,
+            openai_base_url=base_config.openai_base_url,
         )
 
         self.agent = compile_cdk_agent()

--- a/src/generate/nodes/compare_inventory.py
+++ b/src/generate/nodes/compare_inventory.py
@@ -10,8 +10,7 @@ import json
 import re
 from typing import Any, Dict, List
 
-import boto3
-
+from ...llm import LLMClient
 from ...models.generation import TrackedResource
 from ..state import GenerationConfig, GenerationState, emit_progress
 
@@ -95,25 +94,34 @@ def compare_inventory(state: GenerationState) -> Dict[str, Any]:
     )
 
     try:
+        provider_label = config.provider.capitalize()
+        if config.provider == "bedrock":
+            connect_msg = f"Connecting to Bedrock ({config.bedrock_region})"
+        else:
+            connect_msg = f"Connecting to {provider_label}"
         emit_progress(
             "activity",
             {
-                "message": f"Connecting to Bedrock ({config.bedrock_region})",
+                "message": connect_msg,
                 "step": "compare_inventory",
             },
         )
 
-        client = boto3.client("bedrock-runtime", region_name=config.bedrock_region)
+        llm_client = LLMClient(config.to_llm_config())
 
         system_prompt = _get_comparison_system_prompt()
         user_prompt = _format_comparison_prompt(inventory_text, terraform_text, len(resources))
 
+        if config.provider == "bedrock":
+            model_label = config.bedrock_model_id
+        else:
+            model_label = config.openai_model
         emit_progress(
             "activity",
             {
                 "message": "Calling AI to analyze coverage",
                 "step": "compare_inventory",
-                "model": config.bedrock_model_id,
+                "model": model_label,
             },
         )
 
@@ -122,61 +130,35 @@ def compare_inventory(state: GenerationState) -> Dict[str, Any]:
         token_count = 0
 
         try:
-            stream_response = client.converse_stream(
-                modelId=config.bedrock_model_id,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": [{"text": user_prompt}],
-                    }
-                ],
-                system=[{"text": system_prompt}],
-                inferenceConfig={
-                    "temperature": 0.1,
-                    "maxTokens": config.max_tokens,
-                },
-            )
+            for chunk in llm_client.stream(
+                messages=[{"role": "user", "content": user_prompt}],
+                system=system_prompt,
+                temperature=0.1,
+                max_tokens=config.max_tokens,
+            ):
+                response_text += chunk
+                token_count += 1
+                if token_count % 50 == 0:
+                    emit_progress(
+                        "activity",
+                        {
+                            "message": f"Analyzing... ({token_count} tokens)",
+                            "step": "compare_inventory",
+                            "tokens": token_count,
+                        },
+                    )
 
-            # Stream is an EventStream object
-            event_stream = stream_response.get("stream")
-            if event_stream:
-                for event in event_stream:
-                    if "contentBlockDelta" in event:
-                        delta = event["contentBlockDelta"].get("delta", {})
-                        if "text" in delta:
-                            response_text += delta["text"]
-                            token_count += 1
-                            if token_count % 50 == 0:
-                                emit_progress(
-                                    "activity",
-                                    {
-                                        "message": f"Analyzing... ({token_count} tokens)",
-                                        "step": "compare_inventory",
-                                        "tokens": token_count,
-                                    },
-                                )
-
-            # If streaming didn't produce any text, fall back to non-streaming
             if not response_text:
                 raise ValueError("Streaming produced no output")
 
         except Exception:
             # Fall back to non-streaming
-            response = client.converse(
-                modelId=config.bedrock_model_id,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": [{"text": user_prompt}],
-                    }
-                ],
-                system=[{"text": system_prompt}],
-                inferenceConfig={
-                    "temperature": 0.1,
-                    "maxTokens": config.max_tokens,
-                },
+            response_text = llm_client.complete(
+                messages=[{"role": "user", "content": user_prompt}],
+                system=system_prompt,
+                temperature=0.1,
+                max_tokens=config.max_tokens,
             )
-            response_text = response["output"]["message"]["content"][0]["text"] or ""
 
         emit_progress(
             "activity",

--- a/src/generate/nodes/evaluate_guardrails.py
+++ b/src/generate/nodes/evaluate_guardrails.py
@@ -11,18 +11,18 @@ from ..state import GenerationState, emit_progress
 logger = logging.getLogger(__name__)
 
 
-def _get_bedrock_client() -> Optional[Any]:
-    """Get a Bedrock runtime client for auto-fix.
+def _get_llm_client() -> Optional[Any]:
+    """Get an LLM client for AI operations (auto-fix, AI rules).
 
     Returns:
-        boto3 Bedrock runtime client, or None if unavailable.
+        LLMClient instance, or None if unavailable.
     """
     try:
-        import boto3
+        from src.llm import LLMClient, LLMConfig
 
-        return boto3.client("bedrock-runtime")
+        return LLMClient(LLMConfig.from_env())
     except Exception as e:
-        logger.warning(f"Failed to create Bedrock client for auto-fix: {e}")
+        logger.warning(f"Failed to create LLM client for auto-fix: {e}")
         return None
 
 
@@ -91,19 +91,19 @@ def evaluate_guardrails(state: GenerationState) -> Dict[str, Any]:
                 guardrails=builtin,
             )
 
-        # Get Bedrock client for auto-fix if enabled
-        bedrock_client = None
+        # Get LLM client for auto-fix if enabled
+        llm_client = None
         if auto_fix_enabled:
-            bedrock_client = _get_bedrock_client()
-            if bedrock_client:
-                logger.info("Auto-fix enabled with Bedrock AI")
+            llm_client = _get_llm_client()
+            if llm_client:
+                logger.info(f"Auto-fix enabled with {llm_client.provider} AI")
             else:
-                logger.warning("Auto-fix requested but Bedrock client unavailable")
+                logger.warning("Auto-fix requested but LLM client unavailable")
 
         evaluator = GuardrailEvaluator(
             policy=policy,
-            auto_fix_enabled=auto_fix_enabled and bedrock_client is not None,
-            bedrock_client=bedrock_client,
+            auto_fix_enabled=auto_fix_enabled and llm_client is not None,
+            llm_client=llm_client,
             environment=environment,
             output_format=output_format,
         )

--- a/src/generate/nodes/generate_layer.py
+++ b/src/generate/nodes/generate_layer.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import os
 from typing import Any, Callable, Dict, List, Tuple
 
-import boto3
-
+from ...llm import LLMClient
 from ...models.generation import Layer, ResourceMap
 from ..layers import LayerStatus
 from ..prompts.cdk_python import (
@@ -235,16 +234,21 @@ def generate_layer(state: GenerationState) -> Dict[str, Any]:
     )
 
     try:
-        # Emit progress: creating Bedrock client
+        # Emit progress: creating LLM client
+        provider_label = config.provider.capitalize()
+        if config.provider == "bedrock":
+            connect_msg = f"Connecting to Bedrock ({config.bedrock_region})"
+        else:
+            connect_msg = f"Connecting to {provider_label}"
         emit_progress(
             "activity",
             {
-                "message": f"Connecting to Bedrock ({config.bedrock_region})",
+                "message": connect_msg,
                 "layer": layer_name,
             },
         )
 
-        client = boto3.client("bedrock-runtime", region_name=config.bedrock_region)
+        llm_client = LLMClient(config.to_llm_config())
 
         # Emit progress: building prompt
         format_label = _get_format_label(output_format)
@@ -267,12 +271,16 @@ def generate_layer(state: GenerationState) -> Dict[str, Any]:
         )
 
         # Emit progress: calling AI
+        if config.provider == "bedrock":
+            model_label = config.bedrock_model_id.split("/")[-1]
+        else:
+            model_label = config.openai_model
         emit_progress(
             "activity",
             {
-                "message": f"Calling AI to generate {format_label} ({config.bedrock_model_id.split('/')[-1]})",
+                "message": f"Calling AI to generate {format_label} ({model_label})",
                 "layer": layer_name,
-                "model": config.bedrock_model_id,
+                "model": model_label,
             },
         )
 
@@ -281,62 +289,35 @@ def generate_layer(state: GenerationState) -> Dict[str, Any]:
         token_count = 0
 
         try:
-            stream_response = client.converse_stream(
-                modelId=config.bedrock_model_id,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": [{"text": user_prompt}],
-                    }
-                ],
-                system=[{"text": system_prompt}],
-                inferenceConfig={
-                    "temperature": config.temperature,
-                    "maxTokens": config.max_tokens,
-                },
-            )
+            for chunk in llm_client.stream(
+                messages=[{"role": "user", "content": user_prompt}],
+                system=system_prompt,
+                temperature=config.temperature,
+                max_tokens=config.max_tokens,
+            ):
+                generated_code += chunk
+                token_count += 1
+                if token_count % 50 == 0:
+                    emit_progress(
+                        "activity",
+                        {
+                            "message": f"Generating code... ({token_count} tokens)",
+                            "layer": layer_name,
+                            "tokens": token_count,
+                        },
+                    )
 
-            # Stream is an EventStream object
-            event_stream = stream_response.get("stream")
-            if event_stream:
-                for event in event_stream:
-                    if "contentBlockDelta" in event:
-                        delta = event["contentBlockDelta"].get("delta", {})
-                        if "text" in delta:
-                            generated_code += delta["text"]
-                            token_count += 1
-                            # Emit progress every 50 tokens
-                            if token_count % 50 == 0:
-                                emit_progress(
-                                    "activity",
-                                    {
-                                        "message": f"Generating code... ({token_count} tokens)",
-                                        "layer": layer_name,
-                                        "tokens": token_count,
-                                    },
-                                )
-
-            # If streaming didn't produce any code, fall back to non-streaming
             if not generated_code:
                 raise ValueError("Streaming produced no output")
 
         except Exception:
             # Fall back to non-streaming if streaming fails
-            response = client.converse(
-                modelId=config.bedrock_model_id,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": [{"text": user_prompt}],
-                    }
-                ],
-                system=[{"text": system_prompt}],
-                inferenceConfig={
-                    "temperature": config.temperature,
-                    "maxTokens": config.max_tokens,
-                },
+            generated_code = llm_client.complete(
+                messages=[{"role": "user", "content": user_prompt}],
+                system=system_prompt,
+                temperature=config.temperature,
+                max_tokens=config.max_tokens,
             )
-            generated_code = response["output"]["message"]["content"][0]["text"] or ""
 
         # Emit progress: processing response
         emit_progress(

--- a/src/generate/state.py
+++ b/src/generate/state.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from operator import add
-from typing import Any, Callable, Dict, List, Optional  # noqa: F401 - Optional used in TypedDict
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional  # noqa: F401 - Optional used in TypedDict
 
 from typing_extensions import Annotated, TypedDict
+
+if TYPE_CHECKING:
+    from ..llm import LLMConfig
 
 # Type for progress callback: (event_name, event_data) -> None
 ProgressCallback = Callable[[str, Dict[str, Any]], None]
@@ -97,15 +100,23 @@ class GenerationConfig:
     parameterize_env_values: bool = True
     parameterize_sizing: bool = True
     parameterize_naming: bool = True
+    provider: str = "bedrock"
+    openai_model: str = "gpt-4o"
+    openai_api_key: Optional[str] = None
+    openai_base_url: Optional[str] = None
 
     @classmethod
     def from_env(cls) -> GenerationConfig:
         """Create a GenerationConfig from environment variables.
 
         Reads:
-            AWSINV_BEDROCK_MODEL_ID: Bedrock model ID (default: anthropic.claude-sonnet-4-20250514-v1:0)
+            AWSINV_LLM_PROVIDER: LLM provider ("bedrock" or "openai")
+            AWSINV_BEDROCK_MODEL_ID: Bedrock model ID
             AWSINV_BEDROCK_REGION: AWS region for Bedrock (default: us-east-1)
             AWS_DEFAULT_REGION: Fallback for Bedrock region
+            AWSINV_OPENAI_API_KEY: OpenAI API key
+            AWSINV_OPENAI_MODEL: OpenAI model name
+            AWSINV_OPENAI_BASE_URL: OpenAI-compatible base URL
         """
         return cls(
             bedrock_model_id=os.environ.get("AWSINV_BEDROCK_MODEL_ID", "us.anthropic.claude-opus-4-20250514-v1:0"),
@@ -113,4 +124,21 @@ class GenerationConfig:
                 "AWSINV_BEDROCK_REGION",
                 os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
             ),
+            provider=os.environ.get("AWSINV_LLM_PROVIDER", "bedrock"),
+            openai_model=os.environ.get("AWSINV_OPENAI_MODEL", "gpt-4o"),
+            openai_api_key=os.environ.get("AWSINV_OPENAI_API_KEY"),
+            openai_base_url=os.environ.get("AWSINV_OPENAI_BASE_URL"),
+        )
+
+    def to_llm_config(self) -> LLMConfig:
+        """Convert to an LLMConfig for use with LLMClient."""
+        from ..llm import LLMConfig
+
+        return LLMConfig(
+            provider=self.provider,
+            bedrock_model_id=self.bedrock_model_id,
+            bedrock_region=self.bedrock_region,
+            openai_api_key=self.openai_api_key,
+            openai_model=self.openai_model,
+            openai_base_url=self.openai_base_url,
         )

--- a/src/generate/terraform_generator.py
+++ b/src/generate/terraform_generator.py
@@ -124,6 +124,10 @@ class TerraformGenerator:
             bedrock_model_id=model_id or base_config.bedrock_model_id,
             bedrock_region=region or base_config.bedrock_region,
             max_retries=base_config.max_retries,
+            provider=base_config.provider,
+            openai_model=base_config.openai_model,
+            openai_api_key=base_config.openai_api_key,
+            openai_base_url=base_config.openai_base_url,
         )
 
         self.agent = compile_terraform_agent()

--- a/src/guardrails/auto_fix.py
+++ b/src/guardrails/auto_fix.py
@@ -15,7 +15,7 @@ def attempt_auto_fix(
     guardrail: Guardrail,
     resource: Any,
     output_format: str,
-    bedrock_client: Optional[Any] = None,
+    llm_client: Optional[Any] = None,
 ) -> Tuple[bool, Dict[str, Any], str]:
     """Attempt to auto-fix a guardrail violation using AI.
 
@@ -23,7 +23,7 @@ def attempt_auto_fix(
         guardrail: The violated guardrail (must have ai_context).
         resource: The resource that violated.
         output_format: Target format (terraform, cdk-typescript, cdk-python).
-        bedrock_client: Bedrock client for AI call.
+        llm_client: LLMClient instance for AI call.
 
     Returns:
         Tuple of:
@@ -39,11 +39,11 @@ def attempt_auto_fix(
             "Cannot auto-fix: guardrail has no ai_context defined",
         )
 
-    if bedrock_client is None:
+    if llm_client is None:
         return (
             False,
             {},
-            "Cannot auto-fix: Bedrock client not available",
+            "Cannot auto-fix: LLM client not available",
         )
 
     # Get resource config
@@ -52,8 +52,8 @@ def attempt_auto_fix(
     resource_name = getattr(resource, "name", "unknown")
 
     try:
-        result = _call_bedrock_for_fix(
-            bedrock_client=bedrock_client,
+        result = _call_llm_for_fix(
+            llm_client=llm_client,
             guardrail=guardrail,
             resource_type=resource_type,
             resource_name=resource_name,
@@ -83,18 +83,18 @@ def attempt_auto_fix(
         )
 
 
-def _call_bedrock_for_fix(
-    bedrock_client: Any,
+def _call_llm_for_fix(
+    llm_client: Any,
     guardrail: Guardrail,
     resource_type: str,
     resource_name: str,
     resource_config: Dict[str, Any],
     output_format: str,
 ) -> Dict[str, Any]:
-    """Call Bedrock to generate a fix for the violation.
+    """Call LLM to generate a fix for the violation.
 
     Args:
-        bedrock_client: Initialized Bedrock client.
+        llm_client: LLMClient instance.
         guardrail: The violated guardrail.
         resource_type: Type of the resource.
         resource_name: Name of the resource.
@@ -104,7 +104,6 @@ def _call_bedrock_for_fix(
     Returns:
         Dict with success, fix, and description keys.
     """
-    # Build the prompt
     system_prompt = """You are an infrastructure remediation expert. Your task is to generate
 configuration changes that fix security/compliance violations.
 
@@ -143,34 +142,18 @@ OUTPUT FORMAT: {output_format}
 Generate the configuration changes needed to fix this violation."""
 
     try:
-        # Call Bedrock
-        response = bedrock_client.invoke_model(
-            modelId="us.anthropic.claude-opus-4-20250514-v1:0",
-            contentType="application/json",
-            accept="application/json",
-            body=json.dumps(
-                {
-                    "anthropic_version": "bedrock-2023-05-31",
-                    "max_tokens": 2048,
-                    "temperature": 0.2,
-                    "system": system_prompt,
-                    "messages": [
-                        {"role": "user", "content": user_prompt},
-                    ],
-                }
-            ),
+        content = llm_client.complete(
+            messages=[{"role": "user", "content": user_prompt}],
+            system=system_prompt,
+            max_tokens=2048,
+            temperature=0.2,
+            model_override=llm_client.config.get_default_model("auto_fix"),
         )
 
-        # Parse response
-        response_body = json.loads(response["body"].read())
-        content = response_body.get("content", [{}])[0].get("text", "{}")
-
-        # Try to parse the JSON response
         try:
             result = json.loads(content)
             return result
         except json.JSONDecodeError:
-            # Try to extract JSON from the response
             import re
 
             json_match = re.search(r"\{[\s\S]*\}", content)
@@ -183,11 +166,11 @@ Generate the configuration changes needed to fix this violation."""
             }
 
     except Exception as e:
-        logger.error(f"Bedrock API call failed: {e}")
+        logger.error(f"LLM API call failed: {e}")
         return {
             "success": False,
             "fix": {},
-            "description": f"Bedrock API error: {str(e)}",
+            "description": f"LLM API error: {str(e)}",
         }
 
 

--- a/src/guardrails/evaluator.py
+++ b/src/guardrails/evaluator.py
@@ -76,9 +76,9 @@ def evaluate_ai_rule(
     resource_name: str,
     resource_arn: str,
     resource_config: Dict[str, Any],
-    bedrock_client: Optional[Any] = None,
+    llm_client: Optional[Any] = None,
 ) -> Tuple[bool, str]:
-    """Evaluate an AI rule against a resource using Bedrock.
+    """Evaluate an AI rule against a resource using an LLM.
 
     Args:
         rule_text: The AI rule text describing what to check.
@@ -86,15 +86,15 @@ def evaluate_ai_rule(
         resource_name: Name of the resource.
         resource_arn: ARN of the resource.
         resource_config: Resource configuration dictionary.
-        bedrock_client: Bedrock client for AI evaluation.
+        llm_client: LLMClient instance for AI evaluation.
 
     Returns:
         Tuple of (matches: bool, reason: str).
         matches=True means the rule condition matched (potential violation).
     """
-    if bedrock_client is None:
-        logger.warning("No Bedrock client provided for AI rule evaluation")
-        return False, "AI evaluation skipped - no Bedrock client"
+    if llm_client is None:
+        logger.warning("No LLM client provided for AI rule evaluation")
+        return False, "AI evaluation skipped - no LLM client"
 
     try:
         prompt = AI_EVAL_PROMPT.format(
@@ -105,21 +105,11 @@ def evaluate_ai_rule(
             config=_truncate_config(resource_config),
         )
 
-        response = bedrock_client.invoke_model(
-            modelId="anthropic.claude-3-haiku-20240307-v1:0",
-            contentType="application/json",
-            accept="application/json",
-            body=json.dumps(
-                {
-                    "anthropic_version": "bedrock-2023-05-31",
-                    "max_tokens": 256,
-                    "messages": [{"role": "user", "content": prompt}],
-                }
-            ),
+        content = llm_client.complete(
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=256,
+            model_override=llm_client.config.get_default_model("evaluation"),
         )
-
-        response_body = json.loads(response["body"].read())
-        content = response_body.get("content", [{}])[0].get("text", "{}")
 
         # Parse JSON response
         try:
@@ -146,7 +136,7 @@ class GuardrailEvaluator:
         self,
         policy: GuardrailPolicy,
         auto_fix_enabled: bool = True,
-        bedrock_client: Optional[Any] = None,
+        llm_client: Optional[Any] = None,
         environment: str = "default",
         output_format: str = "terraform",
     ) -> None:
@@ -155,13 +145,13 @@ class GuardrailEvaluator:
         Args:
             policy: GuardrailPolicy to evaluate against.
             auto_fix_enabled: Whether to attempt AI auto-fixes.
-            bedrock_client: Optional Bedrock client for AI rules and auto-fix.
+            llm_client: Optional LLMClient for AI rules and auto-fix.
             environment: Environment name for policy overrides.
             output_format: Target IaC format (terraform, cdk-typescript, cdk-python).
         """
         self._policy = policy
         self._auto_fix_enabled = auto_fix_enabled
-        self._bedrock_client = bedrock_client
+        self._llm_client = llm_client
         self._environment = environment
         self._output_format = output_format
         self._auto_fixes: Dict[str, Dict[str, Any]] = {}
@@ -317,7 +307,7 @@ class GuardrailEvaluator:
             resource_name=resource_name,
             resource_arn=resource_arn,
             resource_config=resource_config,
-            bedrock_client=self._bedrock_client,
+            llm_client=self._llm_client,
         )
 
         # Determine result based on rule type
@@ -377,7 +367,7 @@ class GuardrailEvaluator:
             guardrail=guardrail,
             resource=ResourceProxy(),
             output_format=self._output_format,
-            bedrock_client=self._bedrock_client,
+            llm_client=self._llm_client,
         )
 
     def evaluate_all(

--- a/src/guardrails/generator.py
+++ b/src/guardrails/generator.py
@@ -127,10 +127,23 @@ Respond ONLY with valid JSON array (no markdown):
 _TRANSLATE_BATCH_SIZE = 10
 
 
+def _invoke_llm(
+    llm_client: Any,
+    prompt: str,
+    max_tokens: int = 4096,
+) -> str:
+    """Invoke LLM and return the text content."""
+    return llm_client.complete(
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=max_tokens,
+        model_override=llm_client.config.get_default_model("evaluation"),
+    )
+
+
 def translate_rules_to_guardrails(
     rules: List[str],
     instructions: Optional[str] = None,
-    bedrock_client: Optional[Any] = None,
+    llm_client: Optional[Any] = None,
 ) -> List[Guardrail]:
     """Translate a list of rule strings into guardrails using AI.
 
@@ -139,13 +152,13 @@ def translate_rules_to_guardrails(
     Args:
         rules: List of rule strings to translate.
         instructions: Optional instructions for interpretation.
-        bedrock_client: Bedrock client for AI generation.
+        llm_client: LLMClient instance for AI generation.
 
     Returns:
         List of successfully translated Guardrail objects.
     """
-    if bedrock_client is None:
-        logger.error("Bedrock client required for guardrail generation")
+    if llm_client is None:
+        logger.error("LLM client required for guardrail generation")
         return []
 
     if not rules:
@@ -164,21 +177,7 @@ def translate_rules_to_guardrails(
         )
 
         try:
-            response = bedrock_client.invoke_model(
-                modelId="anthropic.claude-3-haiku-20240307-v1:0",
-                contentType="application/json",
-                accept="application/json",
-                body=json.dumps(
-                    {
-                        "anthropic_version": "bedrock-2023-05-31",
-                        "max_tokens": 4096,
-                        "messages": [{"role": "user", "content": prompt}],
-                    }
-                ),
-            )
-
-            response_body = json.loads(response["body"].read())
-            content = response_body.get("content", [{}])[0].get("text", "[]")
+            content = _invoke_llm(llm_client, prompt, max_tokens=4096)
 
             guardrails_list = json.loads(content)
             for g_dict in guardrails_list:
@@ -193,41 +192,25 @@ def translate_rules_to_guardrails(
 
 def generate_guardrail(
     requirement: str,
-    bedrock_client: Optional[Any] = None,
+    llm_client: Optional[Any] = None,
 ) -> Optional[Guardrail]:
     """Generate a single guardrail from a natural language requirement.
 
     Args:
         requirement: Natural language description of the requirement.
-        bedrock_client: Bedrock client for AI generation.
+        llm_client: LLMClient instance for AI generation.
 
     Returns:
         Guardrail object or None if generation fails.
     """
-    if bedrock_client is None:
-        logger.error("Bedrock client required for guardrail generation")
+    if llm_client is None:
+        logger.error("LLM client required for guardrail generation")
         return None
 
     try:
         prompt = GENERATE_GUARDRAIL_PROMPT.format(requirement=requirement)
+        content = _invoke_llm(llm_client, prompt, max_tokens=1024)
 
-        response = bedrock_client.invoke_model(
-            modelId="anthropic.claude-3-haiku-20240307-v1:0",
-            contentType="application/json",
-            accept="application/json",
-            body=json.dumps(
-                {
-                    "anthropic_version": "bedrock-2023-05-31",
-                    "max_tokens": 1024,
-                    "messages": [{"role": "user", "content": prompt}],
-                }
-            ),
-        )
-
-        response_body = json.loads(response["body"].read())
-        content = response_body.get("content", [{}])[0].get("text", "{}")
-
-        # Parse JSON response
         guardrail_dict = json.loads(content)
         return _dict_to_guardrail(guardrail_dict)
 
@@ -240,7 +223,7 @@ def generate_guardrails_batch(
     description: str,
     count: int = 5,
     resource_types: Optional[List[str]] = None,
-    bedrock_client: Optional[Any] = None,
+    llm_client: Optional[Any] = None,
 ) -> List[Guardrail]:
     """Generate multiple guardrails from a policy description.
 
@@ -248,13 +231,13 @@ def generate_guardrails_batch(
         description: High-level policy description.
         count: Number of guardrails to generate.
         resource_types: Optional list of resource types to focus on.
-        bedrock_client: Bedrock client for AI generation.
+        llm_client: LLMClient instance for AI generation.
 
     Returns:
         List of Guardrail objects.
     """
-    if bedrock_client is None:
-        logger.error("Bedrock client required for guardrail generation")
+    if llm_client is None:
+        logger.error("LLM client required for guardrail generation")
         return []
 
     try:
@@ -268,23 +251,8 @@ def generate_guardrails_batch(
             context=context,
         )
 
-        response = bedrock_client.invoke_model(
-            modelId="anthropic.claude-3-haiku-20240307-v1:0",
-            contentType="application/json",
-            accept="application/json",
-            body=json.dumps(
-                {
-                    "anthropic_version": "bedrock-2023-05-31",
-                    "max_tokens": 4096,
-                    "messages": [{"role": "user", "content": prompt}],
-                }
-            ),
-        )
+        content = _invoke_llm(llm_client, prompt, max_tokens=4096)
 
-        response_body = json.loads(response["body"].read())
-        content = response_body.get("content", [{}])[0].get("text", "[]")
-
-        # Parse JSON response
         guardrails_list = json.loads(content)
         return [_dict_to_guardrail(g) for g in guardrails_list if g]
 
@@ -297,7 +265,7 @@ def generate_guardrail_from_violation(
     resource_type: str,
     resource_config: Dict[str, Any],
     violation_description: str,
-    bedrock_client: Optional[Any] = None,
+    llm_client: Optional[Any] = None,
 ) -> Optional[Guardrail]:
     """Generate a guardrail based on an observed violation.
 
@@ -307,13 +275,13 @@ def generate_guardrail_from_violation(
         resource_type: Type of the resource with the violation.
         resource_config: Configuration of the violating resource.
         violation_description: Description of what's wrong.
-        bedrock_client: Bedrock client for AI generation.
+        llm_client: LLMClient instance for AI generation.
 
     Returns:
         Guardrail object that would catch this violation.
     """
-    if bedrock_client is None:
-        logger.error("Bedrock client required for guardrail generation")
+    if llm_client is None:
+        logger.error("LLM client required for guardrail generation")
         return None
 
     try:
@@ -339,21 +307,7 @@ Respond ONLY with valid JSON:
   "tags": ["tag1", "tag2"]
 }}"""
 
-        response = bedrock_client.invoke_model(
-            modelId="anthropic.claude-3-haiku-20240307-v1:0",
-            contentType="application/json",
-            accept="application/json",
-            body=json.dumps(
-                {
-                    "anthropic_version": "bedrock-2023-05-31",
-                    "max_tokens": 1024,
-                    "messages": [{"role": "user", "content": prompt}],
-                }
-            ),
-        )
-
-        response_body = json.loads(response["body"].read())
-        content = response_body.get("content", [{}])[0].get("text", "{}")
+        content = _invoke_llm(llm_client, prompt, max_tokens=1024)
 
         guardrail_dict = json.loads(content)
         return _dict_to_guardrail(guardrail_dict)

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -1,0 +1,5 @@
+"""Unified LLM client abstraction for Bedrock and OpenAI providers."""
+
+from .client import DEFAULT_MODELS, LLMClient, LLMConfig
+
+__all__ = ["LLMClient", "LLMConfig", "DEFAULT_MODELS"]

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -1,0 +1,297 @@
+"""Unified LLM client supporting AWS Bedrock and OpenAI providers."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, List, Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    from openai import OpenAI
+
+    OPENAI_AVAILABLE = True
+except ImportError:
+    OPENAI_AVAILABLE = False
+    OpenAI = None  # type: ignore[assignment, misc]
+
+DEFAULT_MODELS: Dict[str, Dict[str, str]] = {
+    "bedrock": {
+        "generation": "us.anthropic.claude-opus-4-20250514-v1:0",
+        "evaluation": "anthropic.claude-3-haiku-20240307-v1:0",
+        "auto_fix": "us.anthropic.claude-opus-4-20250514-v1:0",
+    },
+    "openai": {
+        "generation": "gpt-4o",
+        "evaluation": "gpt-4o-mini",
+        "auto_fix": "gpt-4o",
+    },
+}
+
+
+@dataclass
+class LLMConfig:
+    """Configuration for the unified LLM client."""
+
+    provider: str = "bedrock"
+    bedrock_model_id: str = "us.anthropic.claude-opus-4-20250514-v1:0"
+    bedrock_region: str = "us-east-1"
+    openai_api_key: Optional[str] = None
+    openai_model: str = "gpt-4o"
+    openai_base_url: Optional[str] = None
+
+    @classmethod
+    def from_env(cls) -> LLMConfig:
+        """Create config from environment variables.
+
+        Reads:
+            AWSINV_LLM_PROVIDER: "bedrock" (default) or "openai"
+            AWSINV_BEDROCK_MODEL_ID: Bedrock model ID
+            AWSINV_BEDROCK_REGION: AWS region for Bedrock
+            AWS_DEFAULT_REGION: Fallback for Bedrock region
+            AWSINV_OPENAI_API_KEY: OpenAI API key
+            AWSINV_OPENAI_MODEL: OpenAI model name
+            AWSINV_OPENAI_BASE_URL: OpenAI-compatible base URL
+        """
+        return cls(
+            provider=os.environ.get("AWSINV_LLM_PROVIDER", "bedrock"),
+            bedrock_model_id=os.environ.get(
+                "AWSINV_BEDROCK_MODEL_ID",
+                "us.anthropic.claude-opus-4-20250514-v1:0",
+            ),
+            bedrock_region=os.environ.get(
+                "AWSINV_BEDROCK_REGION",
+                os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+            ),
+            openai_api_key=os.environ.get("AWSINV_OPENAI_API_KEY"),
+            openai_model=os.environ.get("AWSINV_OPENAI_MODEL", "gpt-4o"),
+            openai_base_url=os.environ.get("AWSINV_OPENAI_BASE_URL"),
+        )
+
+    def get_default_model(self, task: str) -> str:
+        """Get the default model for a given task.
+
+        Args:
+            task: One of "generation", "evaluation", "auto_fix".
+
+        Returns:
+            Model identifier string.
+        """
+        provider_defaults = DEFAULT_MODELS.get(self.provider, DEFAULT_MODELS["bedrock"])
+        return provider_defaults.get(task, provider_defaults["generation"])
+
+
+class LLMClient:
+    """Unified client for Bedrock and OpenAI LLM calls."""
+
+    def __init__(self, config: Optional[LLMConfig] = None) -> None:
+        self._config = config or LLMConfig.from_env()
+        self._bedrock_client: Optional[Any] = None
+        self._openai_client: Optional[Any] = None
+
+    @property
+    def provider(self) -> str:
+        return self._config.provider
+
+    @property
+    def config(self) -> LLMConfig:
+        return self._config
+
+    def _get_bedrock_client(self) -> Any:
+        if self._bedrock_client is None:
+            import boto3
+
+            self._bedrock_client = boto3.client(
+                "bedrock-runtime",
+                region_name=self._config.bedrock_region,
+            )
+        return self._bedrock_client
+
+    def _get_openai_client(self) -> Any:
+        if self._openai_client is None:
+            if not OPENAI_AVAILABLE:
+                raise ImportError(
+                    "OpenAI package not installed. Install with: pip install aws-inventory-manager[openai]"
+                )
+            if not self._config.openai_api_key:
+                raise ValueError("OpenAI API key required. Set AWSINV_OPENAI_API_KEY or pass --openai-api-key.")
+            self._openai_client = OpenAI(
+                api_key=self._config.openai_api_key,
+                base_url=self._config.openai_base_url,
+            )
+        return self._openai_client
+
+    def complete(
+        self,
+        messages: List[Dict[str, str]],
+        system: Optional[str] = None,
+        temperature: float = 0.2,
+        max_tokens: int = 4096,
+        model_override: Optional[str] = None,
+    ) -> str:
+        """Non-streaming completion.
+
+        Args:
+            messages: List of {"role": ..., "content": ...} dicts.
+            system: Optional system prompt.
+            temperature: Sampling temperature.
+            max_tokens: Maximum tokens to generate.
+            model_override: Override model for this call.
+
+        Returns:
+            Generated text string.
+        """
+        if self._config.provider == "openai":
+            return self._openai_complete(messages, system, temperature, max_tokens, model_override)
+        return self._bedrock_complete(messages, system, temperature, max_tokens, model_override)
+
+    def stream(
+        self,
+        messages: List[Dict[str, str]],
+        system: Optional[str] = None,
+        temperature: float = 0.2,
+        max_tokens: int = 4096,
+        model_override: Optional[str] = None,
+    ) -> Iterator[str]:
+        """Streaming completion yielding text chunks.
+
+        Args:
+            messages: List of {"role": ..., "content": ...} dicts.
+            system: Optional system prompt.
+            temperature: Sampling temperature.
+            max_tokens: Maximum tokens to generate.
+            model_override: Override model for this call.
+
+        Yields:
+            Text chunks as they arrive.
+        """
+        if self._config.provider == "openai":
+            yield from self._openai_stream(messages, system, temperature, max_tokens, model_override)
+        else:
+            yield from self._bedrock_stream(messages, system, temperature, max_tokens, model_override)
+
+    # --- Bedrock implementation ---
+
+    def _bedrock_complete(
+        self,
+        messages: List[Dict[str, str]],
+        system: Optional[str],
+        temperature: float,
+        max_tokens: int,
+        model_override: Optional[str],
+    ) -> str:
+        client = self._get_bedrock_client()
+        model_id = model_override or self._config.bedrock_model_id
+
+        converse_kwargs = self._build_bedrock_kwargs(messages, system, temperature, max_tokens, model_id)
+        response = client.converse(**converse_kwargs)
+        return response["output"]["message"]["content"][0]["text"] or ""
+
+    def _bedrock_stream(
+        self,
+        messages: List[Dict[str, str]],
+        system: Optional[str],
+        temperature: float,
+        max_tokens: int,
+        model_override: Optional[str],
+    ) -> Iterator[str]:
+        client = self._get_bedrock_client()
+        model_id = model_override or self._config.bedrock_model_id
+
+        converse_kwargs = self._build_bedrock_kwargs(messages, system, temperature, max_tokens, model_id)
+        stream_response = client.converse_stream(**converse_kwargs)
+
+        event_stream = stream_response.get("stream")
+        if event_stream:
+            for event in event_stream:
+                if "contentBlockDelta" in event:
+                    delta = event["contentBlockDelta"].get("delta", {})
+                    text = delta.get("text")
+                    if text:
+                        yield text
+
+    def _build_bedrock_kwargs(
+        self,
+        messages: List[Dict[str, str]],
+        system: Optional[str],
+        temperature: float,
+        max_tokens: int,
+        model_id: str,
+    ) -> Dict[str, Any]:
+        bedrock_messages = [
+            {
+                "role": msg["role"],
+                "content": [{"text": msg["content"]}],
+            }
+            for msg in messages
+        ]
+
+        kwargs: Dict[str, Any] = {
+            "modelId": model_id,
+            "messages": bedrock_messages,
+            "inferenceConfig": {
+                "temperature": temperature,
+                "maxTokens": max_tokens,
+            },
+        }
+        if system:
+            kwargs["system"] = [{"text": system}]
+        return kwargs
+
+    # --- OpenAI implementation ---
+
+    def _openai_complete(
+        self,
+        messages: List[Dict[str, str]],
+        system: Optional[str],
+        temperature: float,
+        max_tokens: int,
+        model_override: Optional[str],
+    ) -> str:
+        client = self._get_openai_client()
+        model = model_override or self._config.openai_model
+
+        openai_messages = self._build_openai_messages(messages, system)
+        response = client.chat.completions.create(
+            model=model,
+            messages=openai_messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        return response.choices[0].message.content or ""
+
+    def _openai_stream(
+        self,
+        messages: List[Dict[str, str]],
+        system: Optional[str],
+        temperature: float,
+        max_tokens: int,
+        model_override: Optional[str],
+    ) -> Iterator[str]:
+        client = self._get_openai_client()
+        model = model_override or self._config.openai_model
+
+        openai_messages = self._build_openai_messages(messages, system)
+        stream = client.chat.completions.create(
+            model=model,
+            messages=openai_messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stream=True,
+        )
+        for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                yield chunk.choices[0].delta.content
+
+    def _build_openai_messages(
+        self,
+        messages: List[Dict[str, str]],
+        system: Optional[str],
+    ) -> List[Dict[str, str]]:
+        openai_messages: List[Dict[str, str]] = []
+        if system:
+            openai_messages.append({"role": "system", "content": system})
+        openai_messages.extend(messages)
+        return openai_messages

--- a/src/patterns/generator.py
+++ b/src/patterns/generator.py
@@ -1,4 +1,4 @@
-"""AI-powered pattern generation using Bedrock."""
+"""AI-powered pattern generation using LLM providers."""
 
 from __future__ import annotations
 
@@ -14,8 +14,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-MODEL_ID = "anthropic.claude-3-haiku-20240307-v1:0"
-ANTHROPIC_VERSION = "bedrock-2023-05-31"
 MAX_TOKENS = 2048
 
 GENERATE_FROM_DESCRIPTION_PROMPT = """\
@@ -107,48 +105,39 @@ Provide concise, actionable guidance on:
 Keep your response under 500 words. Be specific and reference resource types and config keys where relevant."""
 
 
-def _invoke_bedrock(
-    bedrock_client: Any,
+def _invoke_llm(
+    llm_client: Any,
     prompt: str,
     max_tokens: int = MAX_TOKENS,
 ) -> str:
-    """Invoke Bedrock model and return the text content."""
-    response = bedrock_client.invoke_model(
-        modelId=MODEL_ID,
-        contentType="application/json",
-        accept="application/json",
-        body=json.dumps(
-            {
-                "anthropic_version": ANTHROPIC_VERSION,
-                "max_tokens": max_tokens,
-                "messages": [{"role": "user", "content": prompt}],
-            }
-        ),
+    """Invoke LLM and return the text content."""
+    return llm_client.complete(
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=max_tokens,
+        model_override=llm_client.config.get_default_model("evaluation"),
     )
-    response_body = json.loads(response["body"].read())
-    return response_body.get("content", [{}])[0].get("text", "")
 
 
 def generate_from_description(
     description: str,
     instructions: Optional[str] = None,
-    bedrock_client: Optional[Any] = None,
+    llm_client: Optional[Any] = None,
 ) -> Pattern:
     """Generate a pattern from a text description using Bedrock.
 
     Args:
         description: Natural language description of the desired pattern.
         instructions: Optional additional instructions for the AI.
-        bedrock_client: Bedrock runtime client.
+        llm_client: LLMClient instance.
 
     Returns:
         Generated Pattern object.
 
     Raises:
-        ValueError: If bedrock_client is None or generation fails.
+        ValueError: If llm_client is None or generation fails.
     """
-    if bedrock_client is None:
-        raise ValueError("Bedrock credentials required for pattern generation.")
+    if llm_client is None:
+        raise ValueError("LLM credentials required for pattern generation.")
 
     instructions_block = ""
     if instructions:
@@ -159,7 +148,7 @@ def generate_from_description(
         instructions_block=instructions_block,
     )
 
-    content = _invoke_bedrock(bedrock_client, prompt)
+    content = _invoke_llm(llm_client, prompt)
     pattern_dict = json.loads(content)
     return Pattern.from_dict(pattern_dict)
 
@@ -168,7 +157,7 @@ def generate_from_snapshot(
     snapshot_name: str,
     instructions: Optional[str] = None,
     guardrail_names: Optional[List[str]] = None,
-    bedrock_client: Optional[Any] = None,
+    llm_client: Optional[Any] = None,
 ) -> Pattern:
     """Generate a pattern from an existing snapshot using Bedrock.
 
@@ -177,16 +166,16 @@ def generate_from_snapshot(
         instructions: Optional additional instructions for the AI.
         guardrail_names: Guardrail names whose covered properties should be
             excluded from expect fields.
-        bedrock_client: Bedrock runtime client.
+        llm_client: LLMClient instance.
 
     Returns:
         Generated Pattern object.
 
     Raises:
-        ValueError: If bedrock_client is None or generation fails.
+        ValueError: If llm_client is None or generation fails.
     """
-    if bedrock_client is None:
-        raise ValueError("Bedrock credentials required for pattern generation.")
+    if llm_client is None:
+        raise ValueError("LLM credentials required for pattern generation.")
 
     from ..snapshot.storage import SnapshotStorage
 
@@ -228,7 +217,7 @@ def generate_from_snapshot(
         instructions_block=instructions_block,
     )
 
-    content = _invoke_bedrock(bedrock_client, prompt)
+    content = _invoke_llm(llm_client, prompt)
     pattern_dict = json.loads(content)
     pattern = Pattern.from_dict(pattern_dict)
     pattern.source_snapshot = snapshot_name
@@ -239,18 +228,18 @@ def generate_from_snapshot(
 
 def generate_guidance(
     report: "ComparisonReport",
-    bedrock_client: Optional[Any] = None,
+    llm_client: Optional[Any] = None,
 ) -> str:
     """Generate actionable guidance text from a ComparisonReport.
 
     Args:
         report: The comparison report to generate guidance for.
-        bedrock_client: Bedrock runtime client.
+        llm_client: LLMClient instance.
 
     Returns:
         Guidance string. Empty string if Bedrock is unavailable or call fails.
     """
-    if bedrock_client is None:
+    if llm_client is None:
         return ""
 
     try:
@@ -283,7 +272,7 @@ def generate_guidance(
             matches_summary=matches_summary,
         )
 
-        return _invoke_bedrock(bedrock_client, prompt)
+        return _invoke_llm(llm_client, prompt)
     except Exception:
-        logger.debug("Bedrock guidance generation failed", exc_info=True)
+        logger.debug("LLM guidance generation failed", exc_info=True)
         return ""

--- a/tests/unit/cli/test_guardrails_commands.py
+++ b/tests/unit/cli/test_guardrails_commands.py
@@ -1095,7 +1095,7 @@ class TestGenerateCommand:
         assert result.exit_code == 1
         assert "provide a description" in result.stdout.lower() or "error" in result.stdout.lower()
 
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_both_description_and_file(self, mock_get_client: MagicMock, tmp_path: Path) -> None:
         """Exits 1 when both description and --from-file are given."""
         mock_get_client.return_value = MagicMock()
@@ -1109,7 +1109,7 @@ class TestGenerateCommand:
         assert result.exit_code == 1
         assert "cannot use both" in result.stdout.lower()
 
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_format_without_from_file(self, mock_get_client: MagicMock) -> None:
         """Exits 1 when --format used without --from-file."""
         mock_get_client.return_value = MagicMock()
@@ -1120,7 +1120,7 @@ class TestGenerateCommand:
         assert result.exit_code == 1
         assert "only valid with --from-file" in result.stdout.lower()
 
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_instructions_without_from_file(self, mock_get_client: MagicMock) -> None:
         """Exits 1 when --instructions used without --from-file."""
         mock_get_client.return_value = MagicMock()
@@ -1131,7 +1131,7 @@ class TestGenerateCommand:
         assert result.exit_code == 1
         assert "only valid with --from-file" in result.stdout.lower()
 
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_no_bedrock_client(self, mock_get_client: MagicMock) -> None:
         """Generate command exits 1 when Bedrock client unavailable."""
         mock_get_client.return_value = None
@@ -1143,7 +1143,7 @@ class TestGenerateCommand:
 
     @patch("src.guardrails.generator.guardrail_to_yaml")
     @patch("src.guardrails.generator.generate_guardrail")
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_single_requirement(
         self,
         mock_get_client: MagicMock,
@@ -1161,7 +1161,7 @@ class TestGenerateCommand:
         mock_gen.assert_called_once()
 
     @patch("src.guardrails.generator.generate_guardrail")
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_single_fails(self, mock_get_client: MagicMock, mock_gen: MagicMock) -> None:
         """Single mode exits 1 when generation returns None."""
         mock_get_client.return_value = MagicMock()
@@ -1175,7 +1175,7 @@ class TestGenerateCommand:
 
     @patch("src.guardrails.generator.guardrail_to_yaml")
     @patch("src.guardrails.generator.generate_guardrails_batch")
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_batch_success(
         self,
         mock_get_client: MagicMock,
@@ -1192,7 +1192,7 @@ class TestGenerateCommand:
         assert "generated 2 guardrail" in result.stdout.lower()
 
     @patch("src.guardrails.generator.generate_guardrails_batch")
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_batch_fails(self, mock_get_client: MagicMock, mock_batch: MagicMock) -> None:
         """Batch mode exits 1 when batch generation returns empty/None."""
         mock_get_client.return_value = MagicMock()
@@ -1204,7 +1204,7 @@ class TestGenerateCommand:
 
     @patch("src.guardrails.generator.guardrail_to_yaml")
     @patch("src.guardrails.generator.generate_guardrails_batch")
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_with_types_filter(
         self,
         mock_get_client: MagicMock,
@@ -1225,7 +1225,7 @@ class TestGenerateCommand:
 
     @patch("src.guardrails.generator.guardrail_to_yaml")
     @patch("src.guardrails.generator.generate_guardrails_batch")
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_with_count(
         self,
         mock_get_client: MagicMock,
@@ -1248,7 +1248,7 @@ class TestGenerateCommand:
 
     @patch("src.guardrails.generator.guardrail_to_yaml")
     @patch("src.guardrails.generator.translate_rules_to_guardrails")
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_from_file_txt(
         self,
         mock_get_client: MagicMock,
@@ -1270,7 +1270,7 @@ class TestGenerateCommand:
 
     @patch("src.guardrails.generator.guardrail_to_yaml")
     @patch("src.guardrails.generator.translate_rules_to_guardrails")
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_from_file_with_instructions(
         self,
         mock_get_client: MagicMock,
@@ -1300,7 +1300,7 @@ class TestGenerateCommand:
         assert result.exit_code == 0
         assert mock_translate.call_args.kwargs.get("instructions") == "format is 'ID: description'"
 
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_from_file_not_found(self, mock_get_client: MagicMock) -> None:
         """From-file mode exits 1 when file not found."""
         mock_get_client.return_value = MagicMock()
@@ -1311,7 +1311,7 @@ class TestGenerateCommand:
 
     @patch("src.guardrails.generator.guardrail_to_yaml")
     @patch("src.guardrails.generator.translate_rules_to_guardrails")
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_from_file_partial_failures(
         self,
         mock_get_client: MagicMock,
@@ -1335,7 +1335,7 @@ class TestGenerateCommand:
 
     @patch("src.guardrails.generator.guardrail_to_yaml")
     @patch("src.guardrails.generator.generate_guardrail")
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_output_to_new_file(
         self,
         mock_get_client: MagicMock,
@@ -1361,7 +1361,7 @@ class TestGenerateCommand:
 
     @patch("src.guardrails.generator.guardrail_to_yaml")
     @patch("src.guardrails.generator.generate_guardrail")
-    @patch("src.cli.guardrails._get_bedrock_client")
+    @patch("src.cli.guardrails._get_llm_client")
     def test_generate_output_append_to_existing(
         self,
         mock_get_client: MagicMock,
@@ -1387,25 +1387,22 @@ class TestGenerateCommand:
         assert "GR-GEN-002" in content
 
 
-class TestGetBedrockClient:
-    """Tests for _get_bedrock_client helper."""
+class TestGetLLMClient:
+    """Tests for _get_llm_client helper."""
 
-    @patch("boto3.client")
-    def test_get_bedrock_client_success(self, mock_client_fn: MagicMock) -> None:
-        """Returns Bedrock client on success."""
-        from src.cli.guardrails import _get_bedrock_client
+    @patch("src.llm.client.LLMClient")
+    @patch("src.llm.client.LLMConfig")
+    def test_get_llm_client_success(self, mock_config_cls: MagicMock, mock_client_cls: MagicMock) -> None:
+        """Returns LLMClient on success."""
+        from src.cli.guardrails import _get_llm_client
 
-        mock_client = MagicMock()
-        mock_client_fn.return_value = mock_client
+        result = _get_llm_client()
+        assert result is not None
 
-        result = _get_bedrock_client()
-        assert result == mock_client
-        mock_client_fn.assert_called_once_with("bedrock-runtime")
+    @patch("src.llm.client.LLMConfig.from_env", side_effect=Exception("No credentials"))
+    def test_get_llm_client_failure(self, mock_from_env: MagicMock) -> None:
+        """Returns None when LLMClient creation fails."""
+        from src.cli.guardrails import _get_llm_client
 
-    @patch("boto3.client", side_effect=Exception("No credentials"))
-    def test_get_bedrock_client_failure(self, mock_client_fn: MagicMock) -> None:
-        """Returns None when boto3 client creation fails."""
-        from src.cli.guardrails import _get_bedrock_client
-
-        result = _get_bedrock_client()
+        result = _get_llm_client()
         assert result is None

--- a/tests/unit/cli/test_patterns_commands.py
+++ b/tests/unit/cli/test_patterns_commands.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import io
 import json
 import re
 from pathlib import Path
@@ -52,14 +51,6 @@ SAMPLE_AI_PATTERN_DICT = {
 
 def _strip_ansi(text: str) -> str:
     return re.sub(r"\x1b\[[0-9;]*m", "", text)
-
-
-def _make_bedrock_response(content_dict: dict) -> MagicMock:
-    """Create a mock Bedrock invoke_model response."""
-    body_bytes = json.dumps({"content": [{"text": json.dumps(content_dict)}]}).encode()
-    response = MagicMock()
-    response.__getitem__ = lambda self, key: {"body": io.BytesIO(body_bytes)}[key]
-    return response
 
 
 class TestPatternsAdd:
@@ -163,36 +154,26 @@ class TestPatternsGenerate:
     """Tests for `awsinv patterns generate` command (T015)."""
 
     def test_generate_from_description(self) -> None:
-        mock_boto3 = MagicMock()
-        mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
-
         pattern = Pattern.from_dict(SAMPLE_AI_PATTERN_DICT)
 
-        with patch.dict("sys.modules", {"boto3": mock_boto3}):
-            with patch(
-                "src.patterns.generator.generate_from_description",
-                return_value=pattern,
-            ):
-                result = runner.invoke(app, ["patterns", "generate", "A serverless web API"])
+        with patch(
+            "src.patterns.generator.generate_from_description",
+            return_value=pattern,
+        ):
+            result = runner.invoke(app, ["patterns", "generate", "A serverless web API"])
 
         assert result.exit_code == 0
         output = result.output
         assert "generated-pattern" in output or "lambda:function" in output
 
     def test_generate_from_snapshot(self) -> None:
-        mock_boto3 = MagicMock()
-        mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
-
         pattern = Pattern.from_dict(SAMPLE_AI_PATTERN_DICT)
 
-        with patch.dict("sys.modules", {"boto3": mock_boto3}):
-            with patch(
-                "src.patterns.generator.generate_from_snapshot",
-                return_value=pattern,
-            ):
-                result = runner.invoke(app, ["patterns", "generate", "--from-snapshot", "my-snapshot"])
+        with patch(
+            "src.patterns.generator.generate_from_snapshot",
+            return_value=pattern,
+        ):
+            result = runner.invoke(app, ["patterns", "generate", "--from-snapshot", "my-snapshot"])
 
         assert result.exit_code == 0
         output = result.output
@@ -215,34 +196,26 @@ class TestPatternsGenerate:
         output = _strip_ansi(result.output)
         assert "provide a description" in output.lower() or "from-snapshot" in output.lower()
 
-    def test_no_bedrock_credentials_exit_1(self) -> None:
-        mock_boto3 = MagicMock()
-        mock_boto3.client.side_effect = Exception("No credentials")
-
-        with patch.dict("sys.modules", {"boto3": mock_boto3}):
+    def test_no_llm_credentials_exit_1(self) -> None:
+        with patch("src.llm.client.LLMConfig.from_env", side_effect=Exception("No credentials")):
             result = runner.invoke(app, ["patterns", "generate", "A web API"])
 
         assert result.exit_code == 1
         output = _strip_ansi(result.output)
-        assert "bedrock" in output.lower() or "credentials" in output.lower()
+        assert "credentials" in output.lower() or "error" in output.lower()
 
     def test_generate_with_output_file(self, tmp_path: Path) -> None:
-        mock_boto3 = MagicMock()
-        mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
-
         pattern = Pattern.from_dict(SAMPLE_AI_PATTERN_DICT)
 
-        with patch.dict("sys.modules", {"boto3": mock_boto3}):
-            with patch(
-                "src.patterns.generator.generate_from_description",
-                return_value=pattern,
-            ):
-                output_file = tmp_path / "output.yaml"
-                result = runner.invoke(
-                    app,
-                    ["patterns", "generate", "A web API", "--output", str(output_file)],
-                )
+        with patch(
+            "src.patterns.generator.generate_from_description",
+            return_value=pattern,
+        ):
+            output_file = tmp_path / "output.yaml"
+            result = runner.invoke(
+                app,
+                ["patterns", "generate", "A web API", "--output", str(output_file)],
+            )
 
         assert result.exit_code == 0
         assert output_file.exists()

--- a/tests/unit/generate/test_compare_inventory.py
+++ b/tests/unit/generate/test_compare_inventory.py
@@ -99,14 +99,9 @@ resource "aws_lambda_function" "my_function" {
         }
 
     @pytest.fixture
-    def mock_bedrock_response(self) -> Dict[str, Any]:
-        """Create mock Bedrock API response."""
-        return {
-            "output": {
-                "message": {
-                    "content": [
-                        {
-                            "text": """{
+    def mock_llm_response_text(self) -> str:
+        """Create mock LLM response text."""
+        return """{
     "coverage_percentage": 100.0,
     "total_resources": 3,
     "represented_count": 3,
@@ -120,11 +115,6 @@ resource "aws_lambda_function" "my_function" {
     "issues": [],
     "summary": "All 3 inventory resources are represented in the generated Terraform code."
 }"""
-                        }
-                    ]
-                }
-            }
-        }
 
     def test_empty_resources_returns_zero_coverage(self) -> None:
         """Test handling of empty resources list."""
@@ -158,48 +148,44 @@ resource "aws_lambda_function" "my_function" {
         assert len(comparison["missing_resources"]) == 3
         assert len(comparison["issues"]) > 0
 
-    def test_calls_bedrock_with_correct_parameters(
+    def test_calls_llm_client(
         self,
         sample_resources: List[TrackedResource],
         sample_generated_code: Dict[str, str],
-        mock_bedrock_response: Dict[str, Any],
+        mock_llm_response_text: str,
     ) -> None:
-        """Test that compare_inventory calls Bedrock with correct parameters."""
+        """Test that compare_inventory calls LLM client."""
         state: Dict[str, Any] = {
             "resources": sample_resources,
             "generated_code": sample_generated_code,
         }
 
-        mock_client = MagicMock()
-        mock_client.converse.return_value = mock_bedrock_response
-        mock_client.converse_stream.side_effect = Exception("Streaming not available")
+        mock_instance = MagicMock()
+        mock_instance.stream.side_effect = Exception("Streaming not available")
+        mock_instance.complete.return_value = mock_llm_response_text
 
-        with patch("boto3.client", return_value=mock_client):
+        with patch("src.generate.nodes.compare_inventory.LLMClient", return_value=mock_instance):
             compare_inventory(state)
 
-            mock_client.converse.assert_called_once()
-            call_kwargs = mock_client.converse.call_args[1]
-            assert "modelId" in call_kwargs
-            assert "messages" in call_kwargs
-            assert "system" in call_kwargs
+            mock_instance.complete.assert_called_once()
 
     def test_parses_successful_response(
         self,
         sample_resources: List[TrackedResource],
         sample_generated_code: Dict[str, str],
-        mock_bedrock_response: Dict[str, Any],
+        mock_llm_response_text: str,
     ) -> None:
-        """Test parsing of successful Bedrock response."""
+        """Test parsing of successful LLM response."""
         state: Dict[str, Any] = {
             "resources": sample_resources,
             "generated_code": sample_generated_code,
         }
 
-        mock_client = MagicMock()
-        mock_client.converse.return_value = mock_bedrock_response
-        mock_client.converse_stream.side_effect = Exception("Streaming not available")
+        mock_instance = MagicMock()
+        mock_instance.stream.side_effect = Exception("Streaming not available")
+        mock_instance.complete.return_value = mock_llm_response_text
 
-        with patch("boto3.client", return_value=mock_client):
+        with patch("src.generate.nodes.compare_inventory.LLMClient", return_value=mock_instance):
             result = compare_inventory(state)
 
             comparison = result["comparison_result"]
@@ -208,22 +194,22 @@ resource "aws_lambda_function" "my_function" {
             assert comparison["missing_count"] == 0
             assert len(comparison["represented_resources"]) == 3
 
-    def test_handles_bedrock_error(
+    def test_handles_llm_error(
         self,
         sample_resources: List[TrackedResource],
         sample_generated_code: Dict[str, str],
     ) -> None:
-        """Test handling of Bedrock API errors."""
+        """Test handling of LLM API errors."""
         state: Dict[str, Any] = {
             "resources": sample_resources,
             "generated_code": sample_generated_code,
         }
 
-        mock_client = MagicMock()
-        mock_client.converse_stream.side_effect = Exception("Streaming not available")
-        mock_client.converse.side_effect = Exception("Bedrock API Error")
+        mock_instance = MagicMock()
+        mock_instance.stream.side_effect = Exception("Streaming not available")
+        mock_instance.complete.side_effect = Exception("LLM API Error")
 
-        with patch("boto3.client", return_value=mock_client):
+        with patch("src.generate.nodes.compare_inventory.LLMClient", return_value=mock_instance):
             result = compare_inventory(state)
 
             assert "comparison_result" in result
@@ -236,7 +222,7 @@ resource "aws_lambda_function" "my_function" {
         self,
         sample_resources: List[TrackedResource],
         sample_generated_code: Dict[str, str],
-        mock_bedrock_response: Dict[str, Any],
+        mock_llm_response_text: str,
     ) -> None:
         """Test that compare_inventory returns a dict for state update."""
         state: Dict[str, Any] = {
@@ -244,11 +230,11 @@ resource "aws_lambda_function" "my_function" {
             "generated_code": sample_generated_code,
         }
 
-        mock_client = MagicMock()
-        mock_client.converse.return_value = mock_bedrock_response
-        mock_client.converse_stream.side_effect = Exception("Streaming not available")
+        mock_instance = MagicMock()
+        mock_instance.stream.side_effect = Exception("Streaming not available")
+        mock_instance.complete.return_value = mock_llm_response_text
 
-        with patch("boto3.client", return_value=mock_client):
+        with patch("src.generate.nodes.compare_inventory.LLMClient", return_value=mock_instance):
             result = compare_inventory(state)
 
             assert isinstance(result, dict)

--- a/tests/unit/generate/test_nodes.py
+++ b/tests/unit/generate/test_nodes.py
@@ -920,19 +920,27 @@ resource "aws_subnet" "public_1" {
 }
 ```"""
 
-    def test_calls_bedrock_client(self, state_with_current_layer: Dict[str, Any], tmp_path: Path) -> None:
-        """Test that generate_layer calls Bedrock client."""
+    def _mock_llm_client(self, response_text: str, stream_fails: bool = True) -> MagicMock:
+        """Create a mock LLMClient for generate_layer tests."""
+        mock_instance = MagicMock()
+        if stream_fails:
+            mock_instance.stream.side_effect = Exception("Streaming not available")
+            mock_instance.complete.return_value = response_text
+        else:
+            mock_instance.stream.return_value = iter([response_text])
+            mock_instance.complete.return_value = response_text
+        return mock_instance
+
+    def test_calls_llm_client(self, state_with_current_layer: Dict[str, Any], tmp_path: Path) -> None:
+        """Test that generate_layer calls LLM client."""
         state_with_current_layer["output_dir"] = str(tmp_path)
 
-        mock_client = MagicMock()
-        mock_response = {"output": {"message": {"content": [{"text": "```hcl\n# test\n```"}]}}}
-        mock_client.converse.return_value = mock_response
-        mock_client.converse_stream.side_effect = Exception("Streaming not available")
+        mock_instance = self._mock_llm_client("```hcl\n# test\n```")
 
-        with patch("boto3.client", return_value=mock_client):
+        with patch("src.generate.nodes.generate_layer.LLMClient", return_value=mock_instance):
             generate_layer(state_with_current_layer)
 
-            mock_client.converse.assert_called_once()
+            mock_instance.complete.assert_called_once()
 
     def test_response_parsing_removes_markdown(
         self, state_with_current_layer: Dict[str, Any], mock_ai_response: str, tmp_path: Path
@@ -940,12 +948,9 @@ resource "aws_subnet" "public_1" {
         """Test that AI response has markdown code blocks stripped."""
         state_with_current_layer["output_dir"] = str(tmp_path)
 
-        mock_client = MagicMock()
-        mock_response = {"output": {"message": {"content": [{"text": mock_ai_response}]}}}
-        mock_client.converse.return_value = mock_response
-        mock_client.converse_stream.side_effect = Exception("Streaming not available")
+        mock_instance = self._mock_llm_client(mock_ai_response)
 
-        with patch("boto3.client", return_value=mock_client):
+        with patch("src.generate.nodes.generate_layer.LLMClient", return_value=mock_instance):
             result = generate_layer(state_with_current_layer)
 
             if "generated_code" in result:
@@ -967,12 +972,9 @@ resource "aws_subnet" "public_1" {
 }
 ```"""
 
-        mock_client = MagicMock()
-        mock_response = {"output": {"message": {"content": [{"text": ai_response_with_hardcoded_ids}]}}}
-        mock_client.converse.return_value = mock_response
-        mock_client.converse_stream.side_effect = Exception("Streaming not available")
+        mock_instance = self._mock_llm_client(ai_response_with_hardcoded_ids)
 
-        with patch("boto3.client", return_value=mock_client):
+        with patch("src.generate.nodes.generate_layer.LLMClient", return_value=mock_instance):
             result = generate_layer(state_with_current_layer)
 
             if "generated_code" in result:
@@ -984,11 +986,11 @@ resource "aws_subnet" "public_1" {
         """Test handling of AI API errors."""
         state_with_current_layer["output_dir"] = str(tmp_path)
 
-        mock_client = MagicMock()
-        mock_client.converse_stream.side_effect = Exception("Streaming not available")
-        mock_client.converse.side_effect = Exception("Bedrock API Error")
+        mock_instance = MagicMock()
+        mock_instance.stream.side_effect = Exception("Streaming not available")
+        mock_instance.complete.side_effect = Exception("LLM API Error")
 
-        with patch("boto3.client", return_value=mock_client):
+        with patch("src.generate.nodes.generate_layer.LLMClient", return_value=mock_instance):
             result = generate_layer(state_with_current_layer)
 
             assert "errors" in result or "current_layer_status" in result
@@ -1001,12 +1003,9 @@ resource "aws_subnet" "public_1" {
         """Test that layer status is updated on successful generation."""
         state_with_current_layer["output_dir"] = str(tmp_path)
 
-        mock_client = MagicMock()
-        mock_response = {"output": {"message": {"content": [{"text": mock_ai_response}]}}}
-        mock_client.converse.return_value = mock_response
-        mock_client.converse_stream.side_effect = Exception("Streaming not available")
+        mock_instance = self._mock_llm_client(mock_ai_response)
 
-        with patch("boto3.client", return_value=mock_client):
+        with patch("src.generate.nodes.generate_layer.LLMClient", return_value=mock_instance):
             result = generate_layer(state_with_current_layer)
 
             if "current_layer_status" in result:
@@ -1018,12 +1017,9 @@ resource "aws_subnet" "public_1" {
         """Test that current_layer_index is incremented on success."""
         state_with_current_layer["output_dir"] = str(tmp_path)
 
-        mock_client = MagicMock()
-        mock_response = {"output": {"message": {"content": [{"text": mock_ai_response}]}}}
-        mock_client.converse.return_value = mock_response
-        mock_client.converse_stream.side_effect = Exception("Streaming not available")
+        mock_instance = self._mock_llm_client(mock_ai_response)
 
-        with patch("boto3.client", return_value=mock_client):
+        with patch("src.generate.nodes.generate_layer.LLMClient", return_value=mock_instance):
             result = generate_layer(state_with_current_layer)
 
             if "current_layer_index" in result:
@@ -1035,12 +1031,9 @@ resource "aws_subnet" "public_1" {
         """Test that generated Terraform file is written to output directory."""
         state_with_current_layer["output_dir"] = str(tmp_path)
 
-        mock_client = MagicMock()
-        mock_response = {"output": {"message": {"content": [{"text": mock_ai_response}]}}}
-        mock_client.converse.return_value = mock_response
-        mock_client.converse_stream.side_effect = Exception("Streaming not available")
+        mock_instance = self._mock_llm_client(mock_ai_response)
 
-        with patch("boto3.client", return_value=mock_client):
+        with patch("src.generate.nodes.generate_layer.LLMClient", return_value=mock_instance):
             result = generate_layer(state_with_current_layer)
 
             if "generated_files" in result:
@@ -1182,10 +1175,9 @@ class TestNodeReturnTypes:
 
     def test_generate_layer_returns_dict(self, tmp_path: Path) -> None:
         """Test generate_layer returns a dict for state update."""
-        mock_client = MagicMock()
-        mock_response = {"output": {"message": {"content": [{"text": "```hcl\n# test\n```"}]}}}
-        mock_client.converse.return_value = mock_response
-        mock_client.converse_stream.side_effect = Exception("Streaming not available")
+        mock_instance = MagicMock()
+        mock_instance.stream.side_effect = Exception("Streaming not available")
+        mock_instance.complete.return_value = "```hcl\n# test\n```"
 
         state: Dict[str, Any] = {
             "snapshot_name": "test",
@@ -1201,7 +1193,7 @@ class TestNodeReturnTypes:
             "max_attempts": 3,
         }
 
-        with patch("boto3.client", return_value=mock_client):
+        with patch("src.generate.nodes.generate_layer.LLMClient", return_value=mock_instance):
             result = generate_layer(state)
 
             assert isinstance(result, dict)

--- a/tests/unit/guardrails/test_auto_fix.py
+++ b/tests/unit/guardrails/test_auto_fix.py
@@ -39,7 +39,7 @@ class TestAttemptAutoFix:
             guardrail=guardrail,
             resource=resource,
             output_format="terraform",
-            bedrock_client=None,
+            llm_client=None,
         )
 
         # Without ai_context, auto-fix should fail
@@ -47,7 +47,7 @@ class TestAttemptAutoFix:
         assert fix == {}
         assert "ai_context" in description.lower() or "context" in description.lower()
 
-    def test_attempt_auto_fix_no_bedrock_client(self) -> None:
+    def test_attempt_auto_fix_no_llm_client(self) -> None:
         from src.guardrails.auto_fix import attempt_auto_fix
 
         guardrail = self._create_mock_guardrail(ai_context="WHY: Compliance\nHOW TO FIX: Add encryption")
@@ -57,13 +57,13 @@ class TestAttemptAutoFix:
             guardrail=guardrail,
             resource=resource,
             output_format="terraform",
-            bedrock_client=None,
+            llm_client=None,
         )
 
         # Without Bedrock client, auto-fix should fail gracefully
         assert success is False
 
-    @patch("src.guardrails.auto_fix._call_bedrock_for_fix")
+    @patch("src.guardrails.auto_fix._call_llm_for_fix")
     def test_attempt_auto_fix_success(self, mock_bedrock) -> None:
         from src.guardrails.auto_fix import attempt_auto_fix
 
@@ -82,14 +82,14 @@ class TestAttemptAutoFix:
             guardrail=guardrail,
             resource=resource,
             output_format="terraform",
-            bedrock_client=mock_client,
+            llm_client=mock_client,
         )
 
         assert success is True
         assert "server_side_encryption_configuration" in fix
         assert "AES256" in description or "encryption" in description.lower()
 
-    @patch("src.guardrails.auto_fix._call_bedrock_for_fix")
+    @patch("src.guardrails.auto_fix._call_llm_for_fix")
     def test_attempt_auto_fix_bedrock_error(self, mock_bedrock) -> None:
         from src.guardrails.auto_fix import attempt_auto_fix
 
@@ -108,7 +108,7 @@ class TestAttemptAutoFix:
             guardrail=guardrail,
             resource=resource,
             output_format="terraform",
-            bedrock_client=mock_client,
+            llm_client=mock_client,
         )
 
         assert success is False

--- a/tests/unit/guardrails/test_generator.py
+++ b/tests/unit/guardrails/test_generator.py
@@ -3,18 +3,9 @@
 from __future__ import annotations
 
 import json
-from io import BytesIO
 from unittest.mock import MagicMock
 
 from src.guardrails.generator import translate_rules_to_guardrails
-
-
-def _make_bedrock_response(guardrails_json: list) -> MagicMock:
-    """Build a mock Bedrock response body."""
-    body_content = json.dumps({"content": [{"text": json.dumps(guardrails_json)}]}).encode()
-    response = MagicMock()
-    response.__getitem__ = lambda self, key: {"body": BytesIO(body_content)}[key]
-    return response
 
 
 def _sample_guardrail_dict(id: str = "GR-ENC-001", desc: str = "Test guardrail") -> dict:
@@ -30,66 +21,70 @@ def _sample_guardrail_dict(id: str = "GR-ENC-001", desc: str = "Test guardrail")
     }
 
 
+def _make_llm_client(response_data: list) -> MagicMock:
+    """Build a mock LLMClient that returns JSON from complete()."""
+    client = MagicMock()
+    client.complete.return_value = json.dumps(response_data)
+    client.config.get_default_model.return_value = "mock-model"
+    return client
+
+
 class TestTranslateRulesToGuardrails:
     """Tests for translate_rules_to_guardrails()."""
 
-    def test_no_bedrock_client_returns_empty(self) -> None:
-        result = translate_rules_to_guardrails(rules=["rule 1"], bedrock_client=None)
+    def test_no_llm_client_returns_empty(self) -> None:
+        result = translate_rules_to_guardrails(rules=["rule 1"], llm_client=None)
         assert result == []
 
     def test_empty_rules_returns_empty(self) -> None:
-        result = translate_rules_to_guardrails(rules=[], bedrock_client=MagicMock())
+        result = translate_rules_to_guardrails(rules=[], llm_client=MagicMock())
         assert result == []
 
     def test_single_rule_success(self) -> None:
-        client = MagicMock()
-        client.invoke_model.return_value = _make_bedrock_response([_sample_guardrail_dict()])
+        client = _make_llm_client([_sample_guardrail_dict()])
 
-        result = translate_rules_to_guardrails(rules=["S3 must be encrypted"], bedrock_client=client)
+        result = translate_rules_to_guardrails(rules=["S3 must be encrypted"], llm_client=client)
         assert len(result) == 1
         assert result[0].id == "GR-ENC-001"
-        client.invoke_model.assert_called_once()
+        client.complete.assert_called_once()
 
     def test_instructions_injected_into_prompt(self) -> None:
-        client = MagicMock()
-        client.invoke_model.return_value = _make_bedrock_response([_sample_guardrail_dict()])
+        client = _make_llm_client([_sample_guardrail_dict()])
 
         translate_rules_to_guardrails(
             rules=["A1234: S3 encryption"],
             instructions="format is 'ID: description'",
-            bedrock_client=client,
+            llm_client=client,
         )
 
-        call_body = json.loads(client.invoke_model.call_args.kwargs["body"])
-        prompt_text = call_body["messages"][0]["content"]
+        call_kwargs = client.complete.call_args.kwargs
+        prompt_text = call_kwargs["messages"][0]["content"]
         assert "format is 'ID: description'" in prompt_text
 
     def test_batch_splitting(self) -> None:
-        client = MagicMock()
-        client.invoke_model.return_value = _make_bedrock_response([_sample_guardrail_dict()])
+        client = _make_llm_client([_sample_guardrail_dict()])
 
         rules = [f"Rule {i}" for i in range(25)]
-        translate_rules_to_guardrails(rules=rules, bedrock_client=client)
+        translate_rules_to_guardrails(rules=rules, llm_client=client)
 
-        assert client.invoke_model.call_count == 3  # 10 + 10 + 5
+        assert client.complete.call_count == 3  # 10 + 10 + 5
 
     def test_partial_failure(self) -> None:
         client = MagicMock()
+        client.config.get_default_model.return_value = "mock-model"
 
-        good_response = _make_bedrock_response([_sample_guardrail_dict()])
-        client.invoke_model.side_effect = [
-            good_response,
+        client.complete.side_effect = [
+            json.dumps([_sample_guardrail_dict()]),
             Exception("API error"),
         ]
 
         rules = [f"Rule {i}" for i in range(15)]  # 2 batches
-        result = translate_rules_to_guardrails(rules=rules, bedrock_client=client)
+        result = translate_rules_to_guardrails(rules=rules, llm_client=client)
 
         assert len(result) == 1  # Only first batch succeeded
 
     def test_multiple_rules_per_batch(self) -> None:
-        client = MagicMock()
-        client.invoke_model.return_value = _make_bedrock_response(
+        client = _make_llm_client(
             [
                 _sample_guardrail_dict("GR-ENC-001", "Rule 1"),
                 _sample_guardrail_dict("GR-ENC-002", "Rule 2"),
@@ -98,7 +93,7 @@ class TestTranslateRulesToGuardrails:
         )
 
         rules = ["Rule 1", "Rule 2", "Rule 3"]
-        result = translate_rules_to_guardrails(rules=rules, bedrock_client=client)
+        result = translate_rules_to_guardrails(rules=rules, llm_client=client)
 
         assert len(result) == 3
         assert result[0].id == "GR-ENC-001"

--- a/tests/unit/llm/test_client.py
+++ b/tests/unit/llm/test_client.py
@@ -1,0 +1,340 @@
+"""Unit tests for the unified LLM client."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.llm.client import DEFAULT_MODELS, LLMClient, LLMConfig
+
+
+class TestLLMConfig:
+    """Tests for LLMConfig."""
+
+    def test_defaults(self) -> None:
+        config = LLMConfig()
+        assert config.provider == "bedrock"
+        assert config.bedrock_model_id == "us.anthropic.claude-opus-4-20250514-v1:0"
+        assert config.bedrock_region == "us-east-1"
+        assert config.openai_api_key is None
+        assert config.openai_model == "gpt-4o"
+        assert config.openai_base_url is None
+
+    def test_from_env_defaults(self) -> None:
+        env = {k: v for k, v in os.environ.items() if not k.startswith("AWSINV_") and k != "AWS_DEFAULT_REGION"}
+        with patch.dict(os.environ, env, clear=True):
+            config = LLMConfig.from_env()
+        assert config.provider == "bedrock"
+        assert config.bedrock_region == "us-east-1"
+        assert config.openai_api_key is None
+        assert config.openai_model == "gpt-4o"
+
+    def test_from_env_reads_all_vars(self) -> None:
+        env = {
+            "AWSINV_LLM_PROVIDER": "openai",
+            "AWSINV_BEDROCK_MODEL_ID": "anthropic.claude-3-haiku-20240307-v1:0",
+            "AWSINV_BEDROCK_REGION": "eu-west-1",
+            "AWSINV_OPENAI_API_KEY": "sk-test-key",
+            "AWSINV_OPENAI_MODEL": "gpt-4o-mini",
+            "AWSINV_OPENAI_BASE_URL": "https://custom.api.example.com",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = LLMConfig.from_env()
+
+        assert config.provider == "openai"
+        assert config.bedrock_model_id == "anthropic.claude-3-haiku-20240307-v1:0"
+        assert config.bedrock_region == "eu-west-1"
+        assert config.openai_api_key == "sk-test-key"
+        assert config.openai_model == "gpt-4o-mini"
+        assert config.openai_base_url == "https://custom.api.example.com"
+
+    def test_from_env_aws_default_region_fallback(self) -> None:
+        env = {"AWS_DEFAULT_REGION": "ap-southeast-1"}
+        with patch.dict(os.environ, env, clear=True):
+            config = LLMConfig.from_env()
+        assert config.bedrock_region == "ap-southeast-1"
+
+    def test_from_env_bedrock_region_overrides_aws_default(self) -> None:
+        env = {
+            "AWSINV_BEDROCK_REGION": "us-west-2",
+            "AWS_DEFAULT_REGION": "ap-southeast-1",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = LLMConfig.from_env()
+        assert config.bedrock_region == "us-west-2"
+
+    def test_get_default_model_bedrock(self) -> None:
+        config = LLMConfig(provider="bedrock")
+        assert config.get_default_model("generation") == DEFAULT_MODELS["bedrock"]["generation"]
+        assert config.get_default_model("evaluation") == DEFAULT_MODELS["bedrock"]["evaluation"]
+        assert config.get_default_model("auto_fix") == DEFAULT_MODELS["bedrock"]["auto_fix"]
+
+    def test_get_default_model_openai(self) -> None:
+        config = LLMConfig(provider="openai")
+        assert config.get_default_model("generation") == DEFAULT_MODELS["openai"]["generation"]
+        assert config.get_default_model("evaluation") == DEFAULT_MODELS["openai"]["evaluation"]
+        assert config.get_default_model("auto_fix") == DEFAULT_MODELS["openai"]["auto_fix"]
+
+    def test_get_default_model_unknown_task_falls_back_to_generation(self) -> None:
+        config = LLMConfig(provider="bedrock")
+        assert config.get_default_model("unknown_task") == DEFAULT_MODELS["bedrock"]["generation"]
+
+    def test_get_default_model_unknown_provider_falls_back_to_bedrock(self) -> None:
+        config = LLMConfig(provider="unknown")
+        assert config.get_default_model("generation") == DEFAULT_MODELS["bedrock"]["generation"]
+
+
+class TestLLMClientBedrock:
+    """Tests for LLMClient with Bedrock provider."""
+
+    def _make_client(self) -> tuple[LLMClient, MagicMock]:
+        config = LLMConfig(provider="bedrock", bedrock_region="us-east-1")
+        client = LLMClient(config)
+        mock_bedrock = MagicMock()
+        client._bedrock_client = mock_bedrock
+        return client, mock_bedrock
+
+    def test_complete_bedrock(self) -> None:
+        client, mock_bedrock = self._make_client()
+        mock_bedrock.converse.return_value = {"output": {"message": {"content": [{"text": "Hello from Bedrock"}]}}}
+
+        result = client.complete(
+            messages=[{"role": "user", "content": "Hi"}],
+            system="You are helpful.",
+        )
+
+        assert result == "Hello from Bedrock"
+        mock_bedrock.converse.assert_called_once()
+        call_kwargs = mock_bedrock.converse.call_args.kwargs
+        assert call_kwargs["modelId"] == "us.anthropic.claude-opus-4-20250514-v1:0"
+        assert call_kwargs["system"] == [{"text": "You are helpful."}]
+        assert call_kwargs["messages"] == [{"role": "user", "content": [{"text": "Hi"}]}]
+
+    def test_complete_bedrock_model_override(self) -> None:
+        client, mock_bedrock = self._make_client()
+        mock_bedrock.converse.return_value = {"output": {"message": {"content": [{"text": "response"}]}}}
+
+        client.complete(
+            messages=[{"role": "user", "content": "Hi"}],
+            model_override="anthropic.claude-3-haiku-20240307-v1:0",
+        )
+
+        call_kwargs = mock_bedrock.converse.call_args.kwargs
+        assert call_kwargs["modelId"] == "anthropic.claude-3-haiku-20240307-v1:0"
+
+    def test_complete_bedrock_no_system(self) -> None:
+        client, mock_bedrock = self._make_client()
+        mock_bedrock.converse.return_value = {"output": {"message": {"content": [{"text": "response"}]}}}
+
+        client.complete(messages=[{"role": "user", "content": "Hi"}])
+
+        call_kwargs = mock_bedrock.converse.call_args.kwargs
+        assert "system" not in call_kwargs
+
+    def test_complete_bedrock_temperature_and_max_tokens(self) -> None:
+        client, mock_bedrock = self._make_client()
+        mock_bedrock.converse.return_value = {"output": {"message": {"content": [{"text": "response"}]}}}
+
+        client.complete(
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=0.7,
+            max_tokens=1024,
+        )
+
+        call_kwargs = mock_bedrock.converse.call_args.kwargs
+        assert call_kwargs["inferenceConfig"]["temperature"] == 0.7
+        assert call_kwargs["inferenceConfig"]["maxTokens"] == 1024
+
+    def test_stream_bedrock(self) -> None:
+        client, mock_bedrock = self._make_client()
+        mock_bedrock.converse_stream.return_value = {
+            "stream": [
+                {"contentBlockDelta": {"delta": {"text": "Hello "}}},
+                {"contentBlockDelta": {"delta": {"text": "world"}}},
+                {"contentBlockStop": {}},
+            ]
+        }
+
+        chunks = list(
+            client.stream(
+                messages=[{"role": "user", "content": "Hi"}],
+                system="Be helpful.",
+            )
+        )
+
+        assert chunks == ["Hello ", "world"]
+        mock_bedrock.converse_stream.assert_called_once()
+
+    def test_stream_bedrock_empty_stream(self) -> None:
+        client, mock_bedrock = self._make_client()
+        mock_bedrock.converse_stream.return_value = {"stream": []}
+
+        chunks = list(client.stream(messages=[{"role": "user", "content": "Hi"}]))
+
+        assert chunks == []
+
+    def test_stream_bedrock_no_stream_key(self) -> None:
+        client, mock_bedrock = self._make_client()
+        mock_bedrock.converse_stream.return_value = {}
+
+        chunks = list(client.stream(messages=[{"role": "user", "content": "Hi"}]))
+
+        assert chunks == []
+
+    @patch("boto3.client")
+    def test_lazy_bedrock_client_init(self, mock_boto3: MagicMock) -> None:
+        config = LLMConfig(provider="bedrock", bedrock_region="eu-west-1")
+        client = LLMClient(config)
+        assert client._bedrock_client is None
+
+        mock_boto3.return_value = MagicMock()
+        mock_boto3.return_value.converse.return_value = {"output": {"message": {"content": [{"text": "ok"}]}}}
+
+        client.complete(messages=[{"role": "user", "content": "Hi"}])
+
+        mock_boto3.assert_called_once_with("bedrock-runtime", region_name="eu-west-1")
+        assert client._bedrock_client is not None
+
+
+class TestLLMClientOpenAI:
+    """Tests for LLMClient with OpenAI provider."""
+
+    def _make_client(self) -> tuple[LLMClient, MagicMock]:
+        config = LLMConfig(
+            provider="openai",
+            openai_api_key="sk-test-key",
+            openai_model="gpt-4o",
+        )
+        client = LLMClient(config)
+        mock_openai = MagicMock()
+        client._openai_client = mock_openai
+        return client, mock_openai
+
+    def test_complete_openai(self) -> None:
+        client, mock_openai = self._make_client()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hello from OpenAI"
+        mock_openai.chat.completions.create.return_value = mock_response
+
+        result = client.complete(
+            messages=[{"role": "user", "content": "Hi"}],
+            system="You are helpful.",
+        )
+
+        assert result == "Hello from OpenAI"
+        mock_openai.chat.completions.create.assert_called_once()
+        call_kwargs = mock_openai.chat.completions.create.call_args.kwargs
+        assert call_kwargs["model"] == "gpt-4o"
+        assert call_kwargs["messages"] == [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hi"},
+        ]
+
+    def test_complete_openai_model_override(self) -> None:
+        client, mock_openai = self._make_client()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "response"
+        mock_openai.chat.completions.create.return_value = mock_response
+
+        client.complete(
+            messages=[{"role": "user", "content": "Hi"}],
+            model_override="gpt-4o-mini",
+        )
+
+        call_kwargs = mock_openai.chat.completions.create.call_args.kwargs
+        assert call_kwargs["model"] == "gpt-4o-mini"
+
+    def test_complete_openai_no_system(self) -> None:
+        client, mock_openai = self._make_client()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "response"
+        mock_openai.chat.completions.create.return_value = mock_response
+
+        client.complete(messages=[{"role": "user", "content": "Hi"}])
+
+        call_kwargs = mock_openai.chat.completions.create.call_args.kwargs
+        assert call_kwargs["messages"] == [
+            {"role": "user", "content": "Hi"},
+        ]
+
+    def test_stream_openai(self) -> None:
+        client, mock_openai = self._make_client()
+
+        chunk1 = MagicMock()
+        chunk1.choices = [MagicMock()]
+        chunk1.choices[0].delta.content = "Hello "
+
+        chunk2 = MagicMock()
+        chunk2.choices = [MagicMock()]
+        chunk2.choices[0].delta.content = "world"
+
+        chunk3 = MagicMock()
+        chunk3.choices = [MagicMock()]
+        chunk3.choices[0].delta.content = None
+
+        mock_openai.chat.completions.create.return_value = iter([chunk1, chunk2, chunk3])
+
+        chunks = list(
+            client.stream(
+                messages=[{"role": "user", "content": "Hi"}],
+                system="Be helpful.",
+            )
+        )
+
+        assert chunks == ["Hello ", "world"]
+        call_kwargs = mock_openai.chat.completions.create.call_args.kwargs
+        assert call_kwargs["stream"] is True
+
+    def test_stream_openai_empty_choices(self) -> None:
+        client, mock_openai = self._make_client()
+
+        chunk = MagicMock()
+        chunk.choices = []
+
+        mock_openai.chat.completions.create.return_value = iter([chunk])
+
+        chunks = list(client.stream(messages=[{"role": "user", "content": "Hi"}]))
+
+        assert chunks == []
+
+
+class TestLLMClientErrors:
+    """Tests for LLMClient error handling."""
+
+    def test_openai_missing_package(self) -> None:
+        config = LLMConfig(provider="openai", openai_api_key="sk-test")
+        client = LLMClient(config)
+
+        with patch("src.llm.client.OPENAI_AVAILABLE", False):
+            with pytest.raises(ImportError, match="OpenAI package not installed"):
+                client._openai_client = None
+                client._get_openai_client()
+
+    def test_openai_missing_api_key(self) -> None:
+        config = LLMConfig(provider="openai", openai_api_key=None)
+        client = LLMClient(config)
+
+        with patch("src.llm.client.OPENAI_AVAILABLE", True):
+            with pytest.raises(ValueError, match="OpenAI API key required"):
+                client._get_openai_client()
+
+    def test_provider_property(self) -> None:
+        config = LLMConfig(provider="openai")
+        client = LLMClient(config)
+        assert client.provider == "openai"
+
+    def test_config_property(self) -> None:
+        config = LLMConfig(provider="bedrock")
+        client = LLMClient(config)
+        assert client.config is config
+
+    def test_default_config_from_env(self) -> None:
+        env = {k: v for k, v in os.environ.items() if not k.startswith("AWSINV_") and k != "AWS_DEFAULT_REGION"}
+        with patch.dict(os.environ, env, clear=True):
+            client = LLMClient()
+        assert client.provider == "bedrock"

--- a/tests/unit/patterns/test_generator.py
+++ b/tests/unit/patterns/test_generator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import io
 import json
 from unittest.mock import MagicMock, patch
 
@@ -45,32 +44,26 @@ SAMPLE_PATTERN_DICT = {
 }
 
 
-def _make_bedrock_response(content_dict: dict) -> MagicMock:
-    """Create a mock Bedrock invoke_model response."""
-    body_bytes = json.dumps({"content": [{"text": json.dumps(content_dict)}]}).encode()
-    response = MagicMock()
-    response.__getitem__ = lambda self, key: {"body": io.BytesIO(body_bytes)}[key]
-    return response
-
-
-def _make_bedrock_text_response(text: str) -> MagicMock:
-    """Create a mock Bedrock response with raw text content."""
-    body_bytes = json.dumps({"content": [{"text": text}]}).encode()
-    response = MagicMock()
-    response.__getitem__ = lambda self, key: {"body": io.BytesIO(body_bytes)}[key]
-    return response
+def _make_llm_client(response_data: dict | str) -> MagicMock:
+    """Create a mock LLMClient that returns content from complete()."""
+    client = MagicMock()
+    if isinstance(response_data, dict):
+        client.complete.return_value = json.dumps(response_data)
+    else:
+        client.complete.return_value = response_data
+    client.config.get_default_model.return_value = "mock-model"
+    return client
 
 
 class TestGenerateFromDescription:
     """Tests for generate_from_description (T016)."""
 
     def test_valid_response_returns_pattern(self) -> None:
-        mock_client = MagicMock()
-        mock_client.invoke_model.return_value = _make_bedrock_response(SAMPLE_PATTERN_DICT)
+        mock_client = _make_llm_client(SAMPLE_PATTERN_DICT)
 
         pattern = generate_from_description(
             description="A serverless web API with Lambda and API Gateway",
-            bedrock_client=mock_client,
+            llm_client=mock_client,
         )
 
         assert isinstance(pattern, Pattern)
@@ -79,28 +72,26 @@ class TestGenerateFromDescription:
         assert len(pattern.resources) == 2
         assert pattern.resources[0].type == "lambda:function"
         assert pattern.resources[0].count == 2
-        mock_client.invoke_model.assert_called_once()
+        mock_client.complete.assert_called_once()
 
     def test_instructions_included_in_prompt(self) -> None:
-        mock_client = MagicMock()
-        mock_client.invoke_model.return_value = _make_bedrock_response(SAMPLE_PATTERN_DICT)
+        mock_client = _make_llm_client(SAMPLE_PATTERN_DICT)
 
         generate_from_description(
             description="A web API",
             instructions="Use Python 3.12 runtime and ARM64 architecture",
-            bedrock_client=mock_client,
+            llm_client=mock_client,
         )
 
-        call_args = mock_client.invoke_model.call_args
-        body = json.loads(call_args.kwargs.get("body", call_args[1].get("body", "")))
-        prompt_text = body["messages"][0]["content"]
+        call_kwargs = mock_client.complete.call_args.kwargs
+        prompt_text = call_kwargs["messages"][0]["content"]
         assert "Use Python 3.12 runtime and ARM64 architecture" in prompt_text
 
-    def test_no_bedrock_client_raises_value_error(self) -> None:
-        with pytest.raises(ValueError, match="Bedrock credentials required"):
+    def test_no_llm_client_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="LLM credentials required"):
             generate_from_description(
                 description="A web API",
-                bedrock_client=None,
+                llm_client=None,
             )
 
 
@@ -121,12 +112,11 @@ class TestGenerateFromSnapshot:
         mock_storage.load_snapshot.return_value = mock_snapshot
         mock_storage_cls.return_value = mock_storage
 
-        mock_client = MagicMock()
-        mock_client.invoke_model.return_value = _make_bedrock_response(SAMPLE_PATTERN_DICT)
+        mock_client = _make_llm_client(SAMPLE_PATTERN_DICT)
 
         pattern = generate_from_snapshot(
             snapshot_name="test-snapshot",
-            bedrock_client=mock_client,
+            llm_client=mock_client,
         )
 
         assert isinstance(pattern, Pattern)
@@ -152,17 +142,15 @@ class TestGenerateFromSnapshot:
         mock_storage.load_snapshot.return_value = mock_snapshot
         mock_storage_cls.return_value = mock_storage
 
-        mock_client = MagicMock()
-        mock_client.invoke_model.return_value = _make_bedrock_response(SAMPLE_PATTERN_DICT)
+        mock_client = _make_llm_client(SAMPLE_PATTERN_DICT)
 
         generate_from_snapshot(
             snapshot_name="test-snapshot",
-            bedrock_client=mock_client,
+            llm_client=mock_client,
         )
 
-        call_args = mock_client.invoke_model.call_args
-        body = json.loads(call_args.kwargs.get("body", call_args[1].get("body", "")))
-        prompt_text = body["messages"][0]["content"]
+        call_kwargs = mock_client.complete.call_args.kwargs
+        prompt_text = call_kwargs["messages"][0]["content"]
         assert "lambda:function" in prompt_text
         assert "s3:bucket" in prompt_text
         assert "1 instance(s)" in prompt_text
@@ -181,27 +169,25 @@ class TestGenerateFromSnapshot:
         mock_storage.load_snapshot.return_value = mock_snapshot
         mock_storage_cls.return_value = mock_storage
 
-        mock_client = MagicMock()
-        mock_client.invoke_model.return_value = _make_bedrock_response(SAMPLE_PATTERN_DICT)
+        mock_client = _make_llm_client(SAMPLE_PATTERN_DICT)
 
         generate_from_snapshot(
             snapshot_name="test-snapshot",
             guardrail_names=["encryption-at-rest", "public-access-block"],
-            bedrock_client=mock_client,
+            llm_client=mock_client,
         )
 
-        call_args = mock_client.invoke_model.call_args
-        body = json.loads(call_args.kwargs.get("body", call_args[1].get("body", "")))
-        prompt_text = body["messages"][0]["content"]
+        call_kwargs = mock_client.complete.call_args.kwargs
+        prompt_text = call_kwargs["messages"][0]["content"]
         assert "encryption-at-rest" in prompt_text
         assert "public-access-block" in prompt_text
         assert "Do NOT include expect fields" in prompt_text
 
-    def test_no_bedrock_client_raises_value_error(self) -> None:
-        with pytest.raises(ValueError, match="Bedrock credentials required"):
+    def test_no_llm_client_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="LLM credentials required"):
             generate_from_snapshot(
                 snapshot_name="test-snapshot",
-                bedrock_client=None,
+                llm_client=None,
             )
 
 
@@ -209,10 +195,7 @@ class TestGenerateGuidance:
     """Tests for generate_guidance (T017)."""
 
     def test_returns_guidance_string(self) -> None:
-        mock_client = MagicMock()
-        mock_client.invoke_model.return_value = _make_bedrock_text_response(
-            "You should fix the encryption settings on your S3 buckets."
-        )
+        mock_client = _make_llm_client("You should fix the encryption settings on your S3 buckets.")
 
         report = ComparisonReport(
             snapshot_name="test-snapshot",
@@ -239,22 +222,23 @@ class TestGenerateGuidance:
             threshold=0.25,
         )
 
-        result = generate_guidance(report, bedrock_client=mock_client)
+        result = generate_guidance(report, llm_client=mock_client)
         assert "encryption" in result.lower() or len(result) > 0
-        mock_client.invoke_model.assert_called_once()
+        mock_client.complete.assert_called_once()
 
-    def test_no_bedrock_returns_empty_string(self) -> None:
+    def test_no_llm_client_returns_empty_string(self) -> None:
         report = ComparisonReport(
             snapshot_name="test",
             matches=[],
             threshold=0.25,
         )
-        result = generate_guidance(report, bedrock_client=None)
+        result = generate_guidance(report, llm_client=None)
         assert result == ""
 
-    def test_bedrock_error_returns_empty_string(self) -> None:
+    def test_llm_error_returns_empty_string(self) -> None:
         mock_client = MagicMock()
-        mock_client.invoke_model.side_effect = RuntimeError("Connection timeout")
+        mock_client.config.get_default_model.return_value = "mock-model"
+        mock_client.complete.side_effect = RuntimeError("Connection timeout")
 
         report = ComparisonReport(
             snapshot_name="test",
@@ -294,5 +278,5 @@ class TestGenerateGuidance:
             threshold=0.25,
         )
 
-        result = generate_guidance(report, bedrock_client=mock_client)
+        result = generate_guidance(report, llm_client=mock_client)
         assert result == ""


### PR DESCRIPTION
## Summary

- Add unified `LLMClient` abstraction supporting both AWS Bedrock and OpenAI for all AI features
- New `src/llm/` package with `LLMClient`, `LLMConfig`, and provider-specific default models
- CLI flags: `--provider`, `--openai-model`, `--openai-api-key`, `--openai-base-url`
- Replace all direct boto3 Bedrock calls across 13 source files
- 27 new LLMClient tests, all existing tests updated (3329 passing)
- Documentation updated across 8 files

Closes #134

## Test plan

- [x] All 3329 unit/integration tests pass locally
- [x] `invoke format --check` passes
- [x] `invoke lint` passes
- [x] `invoke typecheck` passes
- [ ] CI passes on all Python versions (3.11, 3.12, 3.13, 3.14)
- [ ] Manual test: Bedrock path (default) works unchanged
- [ ] Manual test: OpenAI path with `--provider openai --openai-api-key sk-...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)